### PR TITLE
Add dark/light variant option to light schemes

### DIFF
--- a/base16/3024.yaml
+++ b/base16/3024.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "3024"
 author: "Jan T. Sott (http://github.com/idleberg)"
+variant: "dark"
 palette:
   base00: "090300" #  ----
   base01: "3a3432" #  ---

--- a/base16/apathy.yaml
+++ b/base16/apathy.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Apathy"
 author: "Jannik Siebert (https://github.com/janniks)"
+variant: "dark"
 palette:
   base00: "031A16"
   base01: "0B342D"

--- a/base16/apprentice.yaml
+++ b/base16/apprentice.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Apprentice"
 author: "romainl"
+variant: "dark"
 palette:
   base00: "262626"
   base01: "AF5F5F"

--- a/base16/ashes.yaml
+++ b/base16/ashes.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Ashes"
 author: "Jannik Siebert (https://github.com/janniks)"
+variant: "dark"
 palette:
   base00: "1C2023" # ----
   base01: "393F45" # ---

--- a/base16/atelier-cave-light.yaml
+++ b/base16/atelier-cave-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Cave Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "efecf4"
   base01: "e2dfe7"

--- a/base16/atelier-cave.yaml
+++ b/base16/atelier-cave.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Cave"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "19171c"
   base01: "26232a"

--- a/base16/atelier-dune-light.yaml
+++ b/base16/atelier-dune-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Dune Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "fefbec"
   base01: "e8e4cf"

--- a/base16/atelier-dune.yaml
+++ b/base16/atelier-dune.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Dune"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "20201d"
   base01: "292824"

--- a/base16/atelier-estuary-light.yaml
+++ b/base16/atelier-estuary-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Estuary Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "f4f3ec"
   base01: "e7e6df"

--- a/base16/atelier-estuary.yaml
+++ b/base16/atelier-estuary.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Estuary"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "22221b"
   base01: "302f27"

--- a/base16/atelier-forest-light.yaml
+++ b/base16/atelier-forest-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Forest Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "f1efee"
   base01: "e6e2e0"

--- a/base16/atelier-forest.yaml
+++ b/base16/atelier-forest.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Forest"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "1b1918"
   base01: "2c2421"

--- a/base16/atelier-heath-light.yaml
+++ b/base16/atelier-heath-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Heath Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "f7f3f7"
   base01: "d8cad8"

--- a/base16/atelier-heath.yaml
+++ b/base16/atelier-heath.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Heath"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "1b181b"
   base01: "292329"

--- a/base16/atelier-lakeside-light.yaml
+++ b/base16/atelier-lakeside-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Lakeside Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "ebf8ff"
   base01: "c1e4f6"

--- a/base16/atelier-lakeside.yaml
+++ b/base16/atelier-lakeside.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Lakeside"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "161b1d"
   base01: "1f292e"

--- a/base16/atelier-plateau-light.yaml
+++ b/base16/atelier-plateau-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Plateau Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "f4ecec"
   base01: "e7dfdf"

--- a/base16/atelier-plateau.yaml
+++ b/base16/atelier-plateau.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Plateau"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "1b1818"
   base01: "292424"

--- a/base16/atelier-savanna-light.yaml
+++ b/base16/atelier-savanna-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Savanna Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "ecf4ee"
   base01: "dfe7e2"

--- a/base16/atelier-savanna.yaml
+++ b/base16/atelier-savanna.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Savanna"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "171c19"
   base01: "232a25"

--- a/base16/atelier-seaside-light.yaml
+++ b/base16/atelier-seaside-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Seaside Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "f4fbf4"
   base01: "cfe8cf"

--- a/base16/atelier-seaside.yaml
+++ b/base16/atelier-seaside.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Seaside"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "131513"
   base01: "242924"

--- a/base16/atelier-sulphurpool-light.yaml
+++ b/base16/atelier-sulphurpool-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Sulphurpool Light"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "light"
 palette:
   base00: "f5f7ff"
   base01: "dfe2f1"

--- a/base16/atelier-sulphurpool.yaml
+++ b/base16/atelier-sulphurpool.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atelier Sulphurpool"
 author: "Bram de Haan (http://atelierbramdehaan.nl)"
+variant: "dark"
 palette:
   base00: "202746"
   base01: "293256"

--- a/base16/atlas.yaml
+++ b/base16/atlas.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Atlas"
 author: "Alex Lende (https://ajlende.com)"
+variant: "dark"
 palette:
   base00: "002635"
   base01: "00384d"

--- a/base16/ayu-dark.yaml
+++ b/base16/ayu-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Ayu Dark"
 author: "Khue Nguyen <Z5483Y@gmail.com>"
+variant: "dark"
 palette:
   base00: "0F1419"
   base01: "131721"

--- a/base16/ayu-light.yaml
+++ b/base16/ayu-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Ayu Light"
 author: "Khue Nguyen <Z5483Y@gmail.com>"
+variant: "light"
 palette:
   base00: "FAFAFA"
   base01: "F3F4F5"

--- a/base16/ayu-mirage.yaml
+++ b/base16/ayu-mirage.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Ayu Mirage"
 author: "Khue Nguyen <Z5483Y@gmail.com>"
+variant: "dark"
 palette:
   base00: "171B24"
   base01: "1F2430"

--- a/base16/black-metal-bathory.yaml
+++ b/base16/black-metal-bathory.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Bathory)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-burzum.yaml
+++ b/base16/black-metal-burzum.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Burzum)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-dark-funeral.yaml
+++ b/base16/black-metal-dark-funeral.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Dark Funeral)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-gorgoroth.yaml
+++ b/base16/black-metal-gorgoroth.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Gorgoroth)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-immortal.yaml
+++ b/base16/black-metal-immortal.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Immortal)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-khold.yaml
+++ b/base16/black-metal-khold.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Khold)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-marduk.yaml
+++ b/base16/black-metal-marduk.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Marduk)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-mayhem.yaml
+++ b/base16/black-metal-mayhem.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Mayhem)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-nile.yaml
+++ b/base16/black-metal-nile.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Nile)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal-venom.yaml
+++ b/base16/black-metal-venom.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal (Venom)"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/black-metal.yaml
+++ b/base16/black-metal.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Black Metal"
 author: "metalelf0 (https://github.com/metalelf0)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "121212"

--- a/base16/blueforest.yaml
+++ b/base16/blueforest.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Blue Forest"
 slug: "blueforest"
 author: "alonsodomin (https://github.com/alonsodomin)"
+variant: "dark"
 palette:
   base00: "141F2E"
   base01: "1e5c1e"

--- a/base16/blueish.yaml
+++ b/base16/blueish.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Blueish"
 author: "Ben Mayoras"
+variant: "dark"
 palette:
   base00: "182430"
   base01: "243C54"

--- a/base16/brewer.yaml
+++ b/base16/brewer.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Brewer"
 author: "Timothée Poisot (http://github.com/tpoisot)"
+variant: "dark"
 palette:
   base00: "0c0d0e" #  ----
   base01: "2e2f30" #  ---

--- a/base16/bright.yaml
+++ b/base16/bright.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Bright"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "303030"

--- a/base16/brogrammer.yaml
+++ b/base16/brogrammer.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Brogrammer"
 author: "Vik Ramanujam (http://github.com/piggyslasher)"
+variant: "dark"
 palette:
   base00: "1f1f1f"
   base01: "f81118"

--- a/base16/brushtrees-dark.yaml
+++ b/base16/brushtrees-dark.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Brush Trees Dark"
 slug: "brushtrees-dark"
 author: "Abraham White <abelincoln.white@gmail.com>"
+variant: "dark"
 palette:
   base00: "485867"
   base01: "5A6D7A"

--- a/base16/brushtrees.yaml
+++ b/base16/brushtrees.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Brush Trees"
 slug: "brushtrees"
 author: "Abraham White <abelincoln.white@gmail.com>"
+variant: "dark"
 palette:
   base00: "E3EFEF"
   base01: "C9DBDC"

--- a/base16/caroline.yaml
+++ b/base16/caroline.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "caroline"
 author: "ed (https://codeberg.org/ed)"
+variant: "dark"
 palette:
   base00: "1c1213"
   base01: "3a2425"

--- a/base16/catppuccin-frappe.yaml
+++ b/base16/catppuccin-frappe.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Catppuccin Frappe"
 author: "https://github.com/catppuccin/catppuccin"
+variant: "dark"
 palette:
   base00: "303446" # base
   base01: "292c3c" # mantle

--- a/base16/catppuccin-latte.yaml
+++ b/base16/catppuccin-latte.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Catppuccin Latte"
 author: "https://github.com/catppuccin/catppuccin"
+variant: "light"
 palette:
   base00: "eff1f5" # base
   base01: "e6e9ef" # mantle

--- a/base16/catppuccin-macchiato.yaml
+++ b/base16/catppuccin-macchiato.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Catppuccin Macchiato"
 author: "https://github.com/catppuccin/catppuccin"
+variant: "dark"
 palette:
   base00: "24273a" # base
   base01: "1e2030" # mantle

--- a/base16/catppuccin-mocha.yaml
+++ b/base16/catppuccin-mocha.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Catppuccin Mocha"
 author: "https://github.com/catppuccin/catppuccin"
+variant: "dark"
 palette:
   base00: "1e1e2e" # base
   base01: "181825" # mantle

--- a/base16/chalk.yaml
+++ b/base16/chalk.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Chalk"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "151515"
   base01: "202020"

--- a/base16/circus.yaml
+++ b/base16/circus.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Circus"
 author: "Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)"
+variant: "dark"
 palette:
   base00: "191919"
   base01: "202020"

--- a/base16/classic-dark.yaml
+++ b/base16/classic-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Classic Dark"
 author: "Jason Heeris (http://heeris.id.au)"
+variant: "dark"
 palette:
   base00: "151515"
   base01: "202020"

--- a/base16/classic-light.yaml
+++ b/base16/classic-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Classic Light"
 author: "Jason Heeris (http://heeris.id.au)"
+variant: "light"
 palette:
   base00: "F5F5F5"
   base01: "E0E0E0"

--- a/base16/codeschool.yaml
+++ b/base16/codeschool.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Codeschool"
 author: "blockloop"
+variant: "dark"
 palette:
   base00: "232c31"
   base01: "1c3657"

--- a/base16/colors.yaml
+++ b/base16/colors.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Colors"
 author: "mrmrs (http://clrs.cc)"
+variant: "dark"
 palette:
   base00: "111111" # Black
   base01: "333333"

--- a/base16/cupcake.yaml
+++ b/base16/cupcake.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Cupcake"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "light"
 palette:
   base00: "fbf1f2"
   base01: "f2f1f4"

--- a/base16/cupertino.yaml
+++ b/base16/cupertino.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Cupertino"
 author: "Defman21"
+variant: "light"
 palette:
   base00: "ffffff" # White
   base01: "c0c0c0"

--- a/base16/da-one-black.yaml
+++ b/base16/da-one-black.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Da One Black"
 author: "NNB (https://github.com/NNBnh)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "282828"

--- a/base16/da-one-gray.yaml
+++ b/base16/da-one-gray.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Da One Gray"
 author: "NNB (https://github.com/NNBnh)"
+variant: "dark"
 palette:
   base00: "181818"
   base01: "282828"

--- a/base16/da-one-ocean.yaml
+++ b/base16/da-one-ocean.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Da One Ocean"
 author: "NNB (https://github.com/NNBnh)"
+variant: "dark"
 palette:
   base00: "171726"
   base01: "22273d"

--- a/base16/da-one-paper.yaml
+++ b/base16/da-one-paper.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Da One Paper"
 author: "NNB (https://github.com/NNBnh)"
+variant: "light"
 palette:
   base00: "faf0dc"
   base01: "c8c8c8"

--- a/base16/da-one-sea.yaml
+++ b/base16/da-one-sea.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Da One Sea"
 author: "NNB (https://github.com/NNBnh)"
+variant: "dark"
 palette:
   base00: "22273d"
   base01: "374059"

--- a/base16/da-one-white.yaml
+++ b/base16/da-one-white.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Da One White"
 author: "NNB (https://github.com/NNBnh)"
+variant: "light"
 palette:
   base00: "ffffff"
   base01: "c8c8c8"

--- a/base16/danqing-light.yaml
+++ b/base16/danqing-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "DanQing Light"
 author: "Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)"
+variant: "light"
 palette:
   base00: "fcfefd" # ++++
   base01: "ecf6f2" # +++

--- a/base16/danqing.yaml
+++ b/base16/danqing.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "DanQing"
 author: "Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)"
+variant: "dark"
 palette:
   base00: "2d302f" # ----
   base01: "434846" # ---

--- a/base16/darcula.yaml
+++ b/base16/darcula.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Darcula"
 author: "jetbrains"
+variant: "dark"
 palette:
   base00: "2b2b2b" # background
   base01: "323232" # line cursor

--- a/base16/darkmoss.yaml
+++ b/base16/darkmoss.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "darkmoss"
 author: "Gabriel Avanzi (https://github.com/avanzzzi)"
+variant: "dark"
 palette:
   base00: "171e1f"
   base01: "252c2d"

--- a/base16/darktooth.yaml
+++ b/base16/darktooth.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Darktooth"
 author: "Jason Milkins (https://github.com/jasonm23)"
+variant: "dark"
 palette:
   base00: "1D2021"
   base01: "32302F"

--- a/base16/darkviolet.yaml
+++ b/base16/darkviolet.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Dark Violet"
 slug: "darkviolet"
 author: "ruler501 (https://github.com/ruler501/base16-darkviolet)"
+variant: "dark"
 palette:
   base00: "000000" #000000 ----
   base01: "231a40" #231a40 ---

--- a/base16/decaf.yaml
+++ b/base16/decaf.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Decaf"
 author: "Alex Mirrington (https://github.com/alexmirrington)"
+variant: "dark"
 palette:
   base00: "2d2d2d"
   base01: "393939"

--- a/base16/default-dark.yaml
+++ b/base16/default-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Default Dark"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "181818"
   base01: "282828"

--- a/base16/default-light.yaml
+++ b/base16/default-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Default Light"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "light"
 palette:
   base00: "f8f8f8"
   base01: "e8e8e8"

--- a/base16/dirtysea.yaml
+++ b/base16/dirtysea.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "dirtysea"
 author: "Kahlil (Kal) Hodgson"
+variant: "light"
 
 palette:
   base00: "e0e0e0" # (light grey) Default Background

--- a/base16/dracula.yaml
+++ b/base16/dracula.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Dracula"
 author: "Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula)"
+variant: "dark"
 palette:
   base00: "282936" #background
   base01: "3a3c4e"

--- a/base16/edge-dark.yaml
+++ b/base16/edge-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Edge Dark"
 author: "cjayross (https://github.com/cjayross)"
+variant: "dark"
 palette:
   base00: "262729"
   base01: "88909f"

--- a/base16/edge-light.yaml
+++ b/base16/edge-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Edge Light"
 author: "cjayross (https://github.com/cjayross)"
+variant: "light"
 palette:
   base00: "fafafa"
   base01: "7c9f4b"

--- a/base16/eighties.yaml
+++ b/base16/eighties.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Eighties"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "2d2d2d"
   base01: "393939"

--- a/base16/embers-light.yaml
+++ b/base16/embers-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Embers Light"
 author: "Jannik Siebert (https://github.com/janniks)"
+variant: "light"
 palette:
   base00: "d1d6db"
   base01: "aeb6be"

--- a/base16/embers.yaml
+++ b/base16/embers.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Embers"
 author: "Jannik Siebert (https://github.com/janniks)"
+variant: "dark"
 palette:
   base00: "16130F" # ----
   base01: "2C2620" # ---

--- a/base16/emil.yaml
+++ b/base16/emil.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "emil"
 author: "limelier"
+variant: "light"
 palette:
   base00: "efefef"
   base01: "bebed2"

--- a/base16/equilibrium-dark.yaml
+++ b/base16/equilibrium-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Equilibrium Dark"
 author: "Carlo Abelli"
+variant: "dark"
 palette:
   base00: "0c1118"
   base01: "181c22"

--- a/base16/equilibrium-gray-dark.yaml
+++ b/base16/equilibrium-gray-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Equilibrium Gray Dark"
 author: "Carlo Abelli"
+variant: "dark"
 palette:
   base00: "111111"
   base01: "1b1b1b"

--- a/base16/equilibrium-gray-light.yaml
+++ b/base16/equilibrium-gray-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Equilibrium Gray Light"
 author: "Carlo Abelli"
+variant: "light"
 palette:
   base00: "f1f1f1"
   base01: "e2e2e2"

--- a/base16/equilibrium-light.yaml
+++ b/base16/equilibrium-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Equilibrium Light"
 author: "Carlo Abelli"
+variant: "light"
 palette:
   base00: "f5f0e7"
   base01: "e7e2d9"

--- a/base16/eris.yaml
+++ b/base16/eris.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "eris"
 author: "ed (https://codeberg.org/ed)"
+variant: "dark"
 palette:
   base00: "0a0920"
   base01: "13133a"

--- a/base16/espresso.yaml
+++ b/base16/espresso.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Espresso"
 author: "Unknown. Maintained by Alex Mirrington (https://github.com/alexmirrington)"
+variant: "dark"
 palette:
   base00: "2d2d2d"
   base01: "393939"

--- a/base16/eva-dim.yaml
+++ b/base16/eva-dim.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Eva Dim"
 author: "kjakapat (https://github.com/kjakapat)"
+variant: "dark"
 palette:
   base00: "2a3b4d"  # default background
   base01: "3d566f"

--- a/base16/eva.yaml
+++ b/base16/eva.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Eva"
 author: "kjakapat (https://github.com/kjakapat)"
+variant: "dark"
 palette:
   base00: "2a3b4d"  # default background
   base01: "3d566f"

--- a/base16/evenok-dark.yaml
+++ b/base16/evenok-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Evenok Dark"
 author: "Mekeor Melire"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "202020"

--- a/base16/everforest-dark-hard.yaml
+++ b/base16/everforest-dark-hard.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Everforest Dark Hard"
 author: "Oskar Liew (https://github.com/OskarLiew)"
+variant: "dark"
 palette:
   base00: "272e33" # bg0,        Default background
   base01: "2e383c" # bg1,        Lighter background

--- a/base16/everforest.yaml
+++ b/base16/everforest.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Everforest"
 author: "Sainnhe Park (https://github.com/sainnhe)"
+variant: "dark"
 palette:
   base00: "2f383e" # bg0,       palette1 dark (medium)
   base01: "374247" # bg1,       palette1 dark (medium)

--- a/base16/flat.yaml
+++ b/base16/flat.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Flat"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "2C3E50"
   base01: "34495E"

--- a/base16/framer.yaml
+++ b/base16/framer.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Framer"
 author: "Framer (Maintained by Jesse Hoyos)"
+variant: "dark"
 palette:
   base00: "181818" # black
   base01: "151515" # ----

--- a/base16/fruit-soda.yaml
+++ b/base16/fruit-soda.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Fruit Soda"
 author: "jozip"
+variant: "light"
 palette:
   base00: "f1ecf1"
   base01: "e0dee0"

--- a/base16/gigavolt.yaml
+++ b/base16/gigavolt.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gigavolt"
 author: "Aidan Swope (http://github.com/Whillikers)"
+variant: "dark"
 palette:
   base00: "202126"
   base01: "2d303d"

--- a/base16/github.yaml
+++ b/base16/github.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Github"
 author: "Defman21"
+variant: "light"
 palette:
   base00: "ffffff"
   base01: "f5f5f5"

--- a/base16/google-dark.yaml
+++ b/base16/google-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Google Dark"
 author: "Seth Wright (http://sethawright.com)"
+variant: "dark"
 palette:
   base00: "1d1f21"
   base01: "282a2e"

--- a/base16/google-light.yaml
+++ b/base16/google-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Google Light"
 author: "Seth Wright (http://sethawright.com)"
+variant: "light"
 palette:
   base00: "ffffff"
   base01: "e0e0e0"

--- a/base16/gotham.yaml
+++ b/base16/gotham.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gotham"
 author: "Andrea Leopardi (arranged by Brett Jones)"
+variant: "dark"
 palette:
   base00: "0c1014"
   base01: "11151c"

--- a/base16/grayscale-dark.yaml
+++ b/base16/grayscale-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Grayscale Dark"
 author: "Alexandre Gavioli (https://github.com/Alexx2/)"
+variant: "dark"
 palette:
   base00: "101010"
   base01: "252525"

--- a/base16/grayscale-light.yaml
+++ b/base16/grayscale-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Grayscale Light"
 author: "Alexandre Gavioli (https://github.com/Alexx2/)"
+variant: "light"
 palette:
   base00: "f7f7f7"
   base01: "e3e3e3"

--- a/base16/greenscreen.yaml
+++ b/base16/greenscreen.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Green Screen"
 slug: "greenscreen"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "001100"
   base01: "003300"

--- a/base16/gruber.yaml
+++ b/base16/gruber.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruber"
 author: "Patel, Nimai <nimai.m.patel@gmail.com>, colors from www.github.com/rexim/gruber-darker-theme"
+variant: "dark"
 palette:
   base00: "181818"
   base01: "453d41"

--- a/base16/gruvbox-dark-hard.yaml
+++ b/base16/gruvbox-dark-hard.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox dark, hard"
 author: "Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)"
+variant: "dark"
 palette:
   base00: "1d2021" # ----
   base01: "3c3836" # ---

--- a/base16/gruvbox-dark-medium.yaml
+++ b/base16/gruvbox-dark-medium.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox dark, medium"
 author: "Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)"
+variant: "dark"
 palette:
   base00: "282828" # ----
   base01: "3c3836" # ---

--- a/base16/gruvbox-dark-pale.yaml
+++ b/base16/gruvbox-dark-pale.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox dark, pale"
 author: "Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)"
+variant: "dark"
 palette:
   base00: "262626" # ----
   base01: "3a3a3a" # ---

--- a/base16/gruvbox-dark-soft.yaml
+++ b/base16/gruvbox-dark-soft.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox dark, soft"
 author: "Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)"
+variant: "dark"
 palette:
   base00: "32302f" # ----
   base01: "3c3836" # ---

--- a/base16/gruvbox-light-hard.yaml
+++ b/base16/gruvbox-light-hard.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox light, hard"
 author: "Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)"
+variant: "light"
 palette:
   base00: "f9f5d7" # ----
   base01: "ebdbb2" # ---

--- a/base16/gruvbox-light-medium.yaml
+++ b/base16/gruvbox-light-medium.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox light, medium"
 author: "Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)"
+variant: "light"
 palette:
   base00: "fbf1c7" # ----
   base01: "ebdbb2" # ---

--- a/base16/gruvbox-light-soft.yaml
+++ b/base16/gruvbox-light-soft.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox light, soft"
 author: "Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)"
+variant: "light"
 palette:
   base00: "f2e5bc" # ----
   base01: "ebdbb2" # ---

--- a/base16/gruvbox-material-dark-hard.yaml
+++ b/base16/gruvbox-material-dark-hard.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox Material Dark, Hard"
 author: "Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)"
+variant: "dark"
 palette:
   base00: "202020"
   base01: "2a2827"

--- a/base16/gruvbox-material-dark-medium.yaml
+++ b/base16/gruvbox-material-dark-medium.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox Material Dark, Medium"
 author: "Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)"
+variant: "dark"
 palette:
   base00: "292828"
   base01: "32302f"

--- a/base16/gruvbox-material-dark-soft.yaml
+++ b/base16/gruvbox-material-dark-soft.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox Material Dark, Soft"
 author: "Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)"
+variant: "dark"
 palette:
   base00: "32302f"
   base01: "3c3836"

--- a/base16/gruvbox-material-light-hard.yaml
+++ b/base16/gruvbox-material-light-hard.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox Material Light, Hard"
 author: "Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)"
+variant: "light"
 palette:
   base00: "f9f5d7"
   base01: "fbf1c7"

--- a/base16/gruvbox-material-light-medium.yaml
+++ b/base16/gruvbox-material-light-medium.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox Material Light, Medium"
 author: "Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)"
+variant: "light"
 palette:
   base00: "fbf1c7"
   base01: "f2e5bc"

--- a/base16/gruvbox-material-light-soft.yaml
+++ b/base16/gruvbox-material-light-soft.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Gruvbox Material Light, Soft"
 author: "Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)"
+variant: "light"
 palette:
   base00: "f2e5bc"
   base01: "ebdbb2"

--- a/base16/hardcore.yaml
+++ b/base16/hardcore.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Hardcore"
 author: "Chris Caller"
+variant: "dark"
 palette:
   base00: "212121" # ----
   base01: "303030" # ---

--- a/base16/harmonic16-dark.yaml
+++ b/base16/harmonic16-dark.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Harmonic16 Dark"
 author: "Jannik Siebert (https://github.com/janniks)"
+variant: "dark"
 palette:
   base00: "0b1c2c"
   base01: "223b54"

--- a/base16/harmonic16-light.yaml
+++ b/base16/harmonic16-light.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Harmonic16 Light"
 author: "Jannik Siebert (https://github.com/janniks)"
+variant: "light"
 palette:
   base00: "f7f9fb"
   base01: "e5ebf1"

--- a/base16/heetch-light.yaml
+++ b/base16/heetch-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Heetch Light"
 author: "Geoffrey Teale (tealeg@gmail.com)"
+variant: "light"
 palette:
   base00: "feffff"
   base01: "392551"

--- a/base16/heetch.yaml
+++ b/base16/heetch.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Heetch Dark"
 slug: "heetch"
 author: "Geoffrey Teale (tealeg@gmail.com)"
+variant: "dark"
 palette:
   base00: "190134"
   base01: "392551"

--- a/base16/helios.yaml
+++ b/base16/helios.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Helios"
 author: "Alex Meyer (https://github.com/reyemxela)"
+variant: "dark"
 palette:
   base00: "1d2021" # ----
   base01: "383c3e" # ---

--- a/base16/hopscotch.yaml
+++ b/base16/hopscotch.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Hopscotch"
 author: "Jan T. Sott"
+variant: "dark"
 palette:
   base00: "322931" # ----
   base01: "433b42" # ---

--- a/base16/horizon-dark.yaml
+++ b/base16/horizon-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Horizon Dark"
 author: "Michaël Ball (http://github.com/michael-ball/)"
+variant: "dark"
 palette:
   base00: "1C1E26"
   base01: "232530"

--- a/base16/horizon-light.yaml
+++ b/base16/horizon-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Horizon Light"
 author: "Michaël Ball (http://github.com/michael-ball/)"
+variant: "light"
 palette:
   base00: "FDF0ED"
   base01: "FADAD1"

--- a/base16/horizon-terminal-dark.yaml
+++ b/base16/horizon-terminal-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Horizon Terminal Dark"
 author: "Michaël Ball (http://github.com/michael-ball/)"
+variant: "dark"
 palette:
   base00: "1C1E26"
   base01: "232530"

--- a/base16/horizon-terminal-light.yaml
+++ b/base16/horizon-terminal-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Horizon Terminal Light"
 author: "Michaël Ball (http://github.com/michael-ball/)"
+variant: "light"
 palette:
   base00: "FDF0ED"
   base01: "FADAD1"

--- a/base16/humanoid-dark.yaml
+++ b/base16/humanoid-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Humanoid dark"
 author: "Thomas (tasmo) Friese"
+variant: "dark"
 palette:
   base00: "232629" # #232629 ----
   base01: "333b3d" # #333b3d ---

--- a/base16/humanoid-light.yaml
+++ b/base16/humanoid-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Humanoid light"
 author: "Thomas (tasmo) Friese"
+variant: "light"
 palette:
   base00: "f8f8f2" # #f8f8f2 ----
   base01: "efefe9" # #efefe9 ---

--- a/base16/ia-dark.yaml
+++ b/base16/ia-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "iA Dark"
 author: "iA Inc. (modified by aramisgithub)"
+variant: "dark"
 palette:
   base00: "1a1a1a"
   base01: "222222"

--- a/base16/ia-light.yaml
+++ b/base16/ia-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "iA Light"
 author: "iA Inc. (modified by aramisgithub)"
+variant: "light"
 palette:
   base00: "f6f6f6"
   base01: "dedede"

--- a/base16/icy.yaml
+++ b/base16/icy.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Icy Dark"
 slug: "icy"
 author: "icyphox (https://icyphox.ga)"
+variant: "light"
 palette:
   base00: "021012"
   base01: "031619"

--- a/base16/irblack.yaml
+++ b/base16/irblack.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "IR Black"
 slug: "irblack"
 author: "Timothée Poisot (http://timotheepoisot.fr)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "242422"

--- a/base16/isotope.yaml
+++ b/base16/isotope.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Isotope"
 author: "Jan T. Sott"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "404040"

--- a/base16/jabuti.yaml
+++ b/base16/jabuti.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Jabuti"
 author: "https://github.com/notusknot"
+variant: "dark"
 palette:
   base00: "292A37"
   base01: "343545"

--- a/base16/kanagawa.yaml
+++ b/base16/kanagawa.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Kanagawa"
 author: "Tommaso Laurenzi (https://github.com/rebelot)"
+variant: "dark"
 palette:
   base00: "1F1F28"
   base01: "16161D"

--- a/base16/katy.yaml
+++ b/base16/katy.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Katy"
 author: "George Essig (https://github.com/gessig)"
+variant: "dark"
 palette:
   base00: "292d3e"
   base01: "444267"

--- a/base16/kimber.yaml
+++ b/base16/kimber.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Kimber"
 author: "Mishka Nguyen (https://github.com/akhsiM)"
+variant: "dark"
 palette:
   base00: "222222"
   base01: "313131"

--- a/base16/lime.yaml
+++ b/base16/lime.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "lime"
 author: "limelier"
+variant: "dark"
 palette:
   base00: "1a1a2f"
   base01: "202030"

--- a/base16/macintosh.yaml
+++ b/base16/macintosh.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Macintosh"
 author: "Rebecca Bettencourt (http://www.kreativekorp.com)"
+variant: "dark"
 palette:
   base00: "000000" # Black
   base01: "404040"

--- a/base16/marrakesh.yaml
+++ b/base16/marrakesh.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Marrakesh"
 author: "Alexandre Gavioli (http://github.com/Alexx2/)"
+variant: "dark"
 palette:
   base00: "201602"
   base01: "302e00"

--- a/base16/materia.yaml
+++ b/base16/materia.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Materia"
 author: "Defman21"
+variant: "dark"
 palette:
   base00: "263238"
   base01: "2C393F"

--- a/base16/material-darker.yaml
+++ b/base16/material-darker.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Material Darker"
 author: "Nate Peterson"
+variant: "dark"
 palette:
   base00: "212121"
   base01: "303030"

--- a/base16/material-lighter.yaml
+++ b/base16/material-lighter.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Material Lighter"
 author: "Nate Peterson"
+variant: "light"
 palette:
   base00: "FAFAFA"
   base01: "E7EAEC"

--- a/base16/material-palenight.yaml
+++ b/base16/material-palenight.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Material Palenight"
 author: "Nate Peterson"
+variant: "dark"
 palette:
   base00: "292D3E"
   base01: "444267"

--- a/base16/material-vivid.yaml
+++ b/base16/material-vivid.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Material Vivid"
 author: "joshyrobot"
+variant: "dark"
 palette:
   base00: "202124"
   base01: "27292c"

--- a/base16/material.yaml
+++ b/base16/material.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Material"
 author: "Nate Peterson"
+variant: "dark"
 palette:
   base00: "263238"
   base01: "2E3C43"

--- a/base16/mellow-purple.yaml
+++ b/base16/mellow-purple.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Mellow Purple"
 author: "gidsi"
+variant: "dark"
 palette:
   base00: "1e0528"
   base01: "1A092D"

--- a/base16/mexico-light.yaml
+++ b/base16/mexico-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Mexico Light"
 author: "Sheldon Johnson"
+variant: "light"
 palette:
   base00: "f8f8f8"
   base01: "e8e8e8"

--- a/base16/mocha.yaml
+++ b/base16/mocha.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Mocha"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "3B3228"
   base01: "534636"

--- a/base16/monokai.yaml
+++ b/base16/monokai.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Monokai"
 author: "Wimer Hazenberg (http://www.monokai.nl)"
+variant: "dark"
 palette:
   base00: "272822"
   base01: "383830"

--- a/base16/mountain.yaml
+++ b/base16/mountain.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Mountain"
 author: "gnsfujiwara (https://github.com/gnsfujiwara)"
+variant: "dark"
 palette:
   base00: "0f0f0f"
   base01: "191919"

--- a/base16/nebula.yaml
+++ b/base16/nebula.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Nebula"
 author: "Gabriel Fontes (https://github.com/Misterio77)"
+variant: "dark"
 
 palette:
   base00: "22273b"

--- a/base16/nord-light.yaml
+++ b/base16/nord-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Nord Light"
 author: "threddast, based on fuxialexander's doom-nord-light-theme (Doom Emacs)"
+variant: "light"
 palette:
   base00: "e5e9f0"
   base01: "c2d0e7"

--- a/base16/nord.yaml
+++ b/base16/nord.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Nord"
 author: "arcticicestudio"
+variant: "dark"
 palette:
   base00: "2E3440"
   base01: "3B4252"

--- a/base16/nova.yaml
+++ b/base16/nova.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Nova"
 author: "George Essig (https://github.com/gessig), Trevor D. Miller (https://trevordmiller.com)"
+variant: "dark"
 palette:
   base00: "3C4C55"
   base01: "556873"

--- a/base16/ocean.yaml
+++ b/base16/ocean.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Ocean"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "2b303b"
   base01: "343d46"

--- a/base16/oceanicnext.yaml
+++ b/base16/oceanicnext.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "OceanicNext"
 author: "https://github.com/voronianski/oceanic-next-color-scheme"
+variant: "dark"
 palette:
   base00: "1B2B34"
   base01: "343D46"

--- a/base16/one-light.yaml
+++ b/base16/one-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "One Light"
 author: "Daniel Pfeifer (http://github.com/purpleKarrot)"
+variant: "light"
 palette:
   base00: "fafafa"
   base01: "f0f0f1"

--- a/base16/onedark.yaml
+++ b/base16/onedark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "OneDark"
 author: "Lalit Magant (http://github.com/tilal6991)"
+variant: "dark"
 palette:
   base00: "282c34"
   base01: "353b45"

--- a/base16/outrun-dark.yaml
+++ b/base16/outrun-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Outrun Dark"
 author: "Hugo Delahousse (http://github.com/hugodelahousse/)"
+variant: "dark"
 palette:
   base00: "00002A"
   base01: "20204A"

--- a/base16/oxocarbon-dark.yaml
+++ b/base16/oxocarbon-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Oxocarbon Dark"
 author: "shaunsingh/IBM"
+variant: "dark"
 palette:
   base00: "161616"
   base01: "262626"

--- a/base16/oxocarbon-light.yaml
+++ b/base16/oxocarbon-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Oxocarbon Light"
 author: "shaunsingh/IBM"
+variant: "light"
 palette:
   base00: "f2f4f8"
   base01: "dde1e6"

--- a/base16/pandora.yaml
+++ b/base16/pandora.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "pandora"
 author: "Cassandra Fox"
+variant: "dark"
 palette:
   base00: "131213"
   base01: "2f1823"

--- a/base16/papercolor-dark.yaml
+++ b/base16/papercolor-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "PaperColor Dark"
 author: "Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)"
+variant: "dark"
 palette:
   base00: "1c1c1c" # Default Background
   base01: "af005f" # Lighter Background (Used for status bars, line number and folding marks)

--- a/base16/papercolor-light.yaml
+++ b/base16/papercolor-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "PaperColor Light"
 author: "Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)"
+variant: "light"
 palette:
   base00: "eeeeee" # Default Background
   base01: "af0000" # Lighter Background (Used for status bars, line number and folding marks)

--- a/base16/paraiso.yaml
+++ b/base16/paraiso.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Paraiso"
 author: "Jan T. Sott"
+variant: "dark"
 palette:
   base00: "2f1e2e" # ----
   base01: "41323f" # ---

--- a/base16/pasque.yaml
+++ b/base16/pasque.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Pasque"
 author: "Gabriel Fontes (https://github.com/Misterio77)"
+variant: "dark"
 
 palette:
   base00: "271C3A"

--- a/base16/phd.yaml
+++ b/base16/phd.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "PhD"
 author: "Hennig Hasemann (http://leetless.de/vim.html)"
+variant: "dark"
 palette:
   base00: "061229"
   base01: "2a3448"

--- a/base16/pico.yaml
+++ b/base16/pico.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Pico"
 author: "PICO-8 (http://www.lexaloffle.com/pico-8.php)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "1d2b53"

--- a/base16/pinky.yaml
+++ b/base16/pinky.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "pinky"
 author: "Benjamin (https://github.com/b3nj5m1n)"
+variant: "dark"
 palette:
   base00: "171517" # default background
   base01: "1b181b" # lighter background (status bar)

--- a/base16/pop.yaml
+++ b/base16/pop.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Pop"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "000000"
   base01: "202020"

--- a/base16/porple.yaml
+++ b/base16/porple.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Porple"
 author: "Niek den Breeje (https://github.com/AuditeMarlow)"
+variant: "dark"
 palette:
   base00: "292c36" # ----
   base01: "333344" # ---

--- a/base16/primer-dark-dimmed.yaml
+++ b/base16/primer-dark-dimmed.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Primer Dark Dimmed"
 author: "Jimmy Lin"
+variant: "dark"
 palette:
   base00: "1c2128"
   base01: "373e47"

--- a/base16/primer-dark.yaml
+++ b/base16/primer-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Primer Dark"
 author: "Jimmy Lin"
+variant: "dark"
 palette:
   base00: "010409"
   base01: "21262d"

--- a/base16/primer-light.yaml
+++ b/base16/primer-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Primer Light"
 author: "Jimmy Lin"
+variant: "light"
 palette:
   base00: "fafbfc"
   base01: "e1e4e8"

--- a/base16/purpledream.yaml
+++ b/base16/purpledream.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Purpledream"
 author: "malet"
+variant: "dark"
 palette:
   base00: "100510"
   base01: "302030"

--- a/base16/qualia.yaml
+++ b/base16/qualia.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Qualia"
 author: "isaacwhanson"
+variant: "dark"
 palette:
   base00: "101010"
   base01: "454545"

--- a/base16/railscasts.yaml
+++ b/base16/railscasts.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Railscasts"
 author: "Ryan Bates (http://railscasts.com)"
+variant: "dark"
 palette:
   base00: "2b2b2b"
   base01: "272935"

--- a/base16/rebecca.yaml
+++ b/base16/rebecca.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Rebecca"
 author: "Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)"
+variant: "dark"
 palette:
   base00: "292a44" # default background
   base01: "663399" # lighter background (status bar)

--- a/base16/rose-pine-dawn.yaml
+++ b/base16/rose-pine-dawn.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Rosé Pine Dawn"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+variant: "light"
 palette:
   base00: "faf4ed"
   base01: "fffaf3"

--- a/base16/rose-pine-moon.yaml
+++ b/base16/rose-pine-moon.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Rosé Pine Moon"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+variant: "dark"
 palette:
   base00: "232136"
   base01: "2a273f"

--- a/base16/rose-pine.yaml
+++ b/base16/rose-pine.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Rosé Pine"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+variant: "dark"
 palette:
   base00: "191724"
   base01: "1f1d2e"

--- a/base16/sagelight.yaml
+++ b/base16/sagelight.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Sagelight"
 author: "Carter Veldhuizen"
+variant: "light"
 palette:
   base00: "f8f8f8"
   base01: "e8e8e8"

--- a/base16/sakura.yaml
+++ b/base16/sakura.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Sakura"
 author: "Misterio77 (http://github.com/Misterio77)"
+variant: "light"
 palette:
   base00: "feedf3"
   base01: "f8e2e7"

--- a/base16/sandcastle.yaml
+++ b/base16/sandcastle.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Sandcastle"
 author: "George Essig (https://github.com/gessig)"
+variant: "dark"
 palette:
   base00: "282c34"
   base01: "2c323b"

--- a/base16/selenized-black.yaml
+++ b/base16/selenized-black.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "selenized-black"
 author: "Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali"
+variant: "dark"
 palette:
   base00: "181818"
   base01: "252525"

--- a/base16/selenized-dark.yaml
+++ b/base16/selenized-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "selenized-dark"
 author: "Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali"
+variant: "dark"
 palette:
   base00: "103c48"
   base01: "184956"

--- a/base16/selenized-light.yaml
+++ b/base16/selenized-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "selenized-light"
 author: "Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali"
+variant: "light"
 palette:
   base00: "fbf3db"
   base01: "ece3cc"

--- a/base16/selenized-white.yaml
+++ b/base16/selenized-white.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "selenized-white"
 author: "Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali"
+variant: "light"
 palette:
   base00: "ffffff"
   base01: "ebebeb"

--- a/base16/seti.yaml
+++ b/base16/seti.yaml
@@ -3,6 +3,7 @@ system: "base16"
 name: "Seti UI"
 slug: "seti"
 author: ""
+variant: "dark"
 palette:
   base00: "151718"
   base01: "282a2b"

--- a/base16/shades-of-purple.yaml
+++ b/base16/shades-of-purple.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Shades of Purple"
 author: "Iolar Demartini Junior (http://github.com/demartini) based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode)."
+variant: "dark"
 palette:
   base00: "1e1e3f" # default background
   base01: "43d426" # lighter background (status bar)

--- a/base16/shadesmear-dark.yaml
+++ b/base16/shadesmear-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "ShadeSmear Dark"
 author: "Kyle Giammarco (http://kyle.giammar.co)"
+variant: "dark"
 palette:
   base00: "232323"
   base01: "1C1C1C"

--- a/base16/shadesmear-light.yaml
+++ b/base16/shadesmear-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "ShadeSmear Light"
 author: "Kyle Giammarco (http://kyle.giammar.co)"
+variant: "light"
 palette:
   base00: "DBDBDB"
   base01: "E4E4E4"

--- a/base16/shapeshifter.yaml
+++ b/base16/shapeshifter.yaml
@@ -2,6 +2,7 @@
 system: "base16"
 name: "Shapeshifter"
 author: "Tyler Benziger (http://tybenz.com)"
+variant: "light"
 palette:
   base00: "f9f9f9" #  ----
   base01: "e0e0e0" #  ---

--- a/base16/silk-dark.yaml
+++ b/base16/silk-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Silk Dark"
 author: "Gabriel Fontes (https://github.com/Misterio77)"
+variant: "dark"
 
 palette:
   base00: "0e3c46"

--- a/base16/silk-light.yaml
+++ b/base16/silk-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Silk Light"
 author: "Gabriel Fontes (https://github.com/Misterio77)"
+variant: "light"
 
 palette:
   base00: "E9F1EF"

--- a/base16/snazzy.yaml
+++ b/base16/snazzy.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Snazzy"
 author: "Chawye Hsu (https://github.com/chawyehsu) based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)"
+variant: "dark"
 palette:
   base00: "282a36"
   base01: "34353e"

--- a/base16/solarflare-light.yaml
+++ b/base16/solarflare-light.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Solar Flare Light"
 slug: "solarflare-light"
 author: "Chuck Harmston (https://chuck.harmston.ch)"
+variant: "light"
 palette:
   base00: "F5F7FA"
   base01: "E8E9ED"

--- a/base16/solarflare.yaml
+++ b/base16/solarflare.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Solar Flare"
 slug: "solarflare"
 author: "Chuck Harmston (https://chuck.harmston.ch)"
+variant: "dark"
 palette:
   base00: "18262F"
   base01: "222E38"

--- a/base16/solarized-dark.yaml
+++ b/base16/solarized-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Solarized Dark"
 author: "Ethan Schoonover (modified by aramisgithub)"
+variant: "dark"
 palette:
   base00: "002b36"
   base01: "073642"

--- a/base16/solarized-light.yaml
+++ b/base16/solarized-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Solarized Light"
 author: "Ethan Schoonover (modified by aramisgithub)"
+variant: "light"
 palette:
   base00: "fdf6e3"
   base01: "eee8d5"

--- a/base16/spaceduck.yaml
+++ b/base16/spaceduck.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Spaceduck"
 author: "Guillermo Rodriguez (https://github.com/pineapplegiant), packaged by Gabriel Fontes (https://github.com/Misterio77)"
+variant: "dark"
 palette:
   base00: "16172d"
   base01: "1b1c36"

--- a/base16/spacemacs.yaml
+++ b/base16/spacemacs.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Spacemacs"
 author: "Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)"
+variant: "dark"
 palette:
   base00: "1f2022" # ----
   base01: "282828" # ---

--- a/base16/standardized-dark.yaml
+++ b/base16/standardized-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "standardized-dark"
 author: "ali (https://github.com/ali-githb/base16-standardized-scheme)"
+variant: "dark"
 palette:
   base00: "222222"
   base01: "303030"

--- a/base16/stella.yaml
+++ b/base16/stella.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Stella"
 author: "Shrimpram"
+variant: "dark"
 palette:
   base00: "2B213C"
   base01: "362B48"

--- a/base16/still-alive.yaml
+++ b/base16/still-alive.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Still Alive"
 author: "Derrick McKee (derrick.mckee@gmail.com)"
+variant: "light"
 palette:
   base00: "F0F0F0"
   base01: "F0D848"

--- a/base16/summercamp.yaml
+++ b/base16/summercamp.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "summercamp"
 author: "zoe firi (zoefiri.github.io)"
+variant: "dark"
 palette:
   base00: "1c1810"
   base01: "2a261c"

--- a/base16/summerfruit-dark.yaml
+++ b/base16/summerfruit-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Summerfruit Dark"
 author: "Christopher Corley (http://christop.club/)"
+variant: "dark"
 palette:
   base00: "151515"
   base01: "202020"

--- a/base16/summerfruit-light.yaml
+++ b/base16/summerfruit-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Summerfruit Light"
 author: "Christopher Corley (http://christop.club/)"
+variant: "light"
 palette:
   base00: "FFFFFF"
   base01: "E0E0E0"

--- a/base16/synth-midnight-dark.yaml
+++ b/base16/synth-midnight-dark.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Synth Midnight Terminal Dark"
 slug: "synth-midnight-dark"
 author: "Michaël Ball (http://github.com/michael-ball/)"
+variant: "dark"
 palette:
   base00: "050608"
   base01: "1a1b1c"

--- a/base16/synth-midnight-light.yaml
+++ b/base16/synth-midnight-light.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Synth Midnight Terminal Light"
 slug: "synth-midnight-light"
 author: "Michaël Ball (http://github.com/michael-ball/)"
+variant: "light"
 palette:
   base00: "dddfe0"
   base01: "cfd1d2"

--- a/base16/tango.yaml
+++ b/base16/tango.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tango"
 author: "@Schnouki, based on the Tango Desktop Project"
+variant: "dark"
 palette:
   base00: "2e3436"
   base01: "8ae234"

--- a/base16/tarot.yaml
+++ b/base16/tarot.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "tarot"
 author: "ed (https://codeberg.org/ed)"
+variant: "dark"
 palette:
   base00: "0e091d"
   base01: "2a153c"

--- a/base16/tender.yaml
+++ b/base16/tender.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "tender"
 author: "Jacobo Tabernero (https://github/com/jacoborus/tender.vim)"
+variant: "dark"
 palette:
   base00: "282828"  # color00 Black (background)
   base01: "383838"  # color18

--- a/base16/tokyo-city-dark.yaml
+++ b/base16/tokyo-city-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo City Dark"
 author: "Michaël Ball"
+variant: "dark"
 palette:
   base00: "171D23"
   base01: "1D252C"

--- a/base16/tokyo-city-light.yaml
+++ b/base16/tokyo-city-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo City Light"
 author: "Michaël Ball"
+variant: "light"
 palette:
   base00: "FBFBFD"
   base01: "F6F6F8"

--- a/base16/tokyo-city-terminal-dark.yaml
+++ b/base16/tokyo-city-terminal-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo City Terminal Dark"
 author: "Michaël Ball"
+variant: "dark"
 palette:
   base00: "171D23"
   base01: "1D252C"

--- a/base16/tokyo-city-terminal-light.yaml
+++ b/base16/tokyo-city-terminal-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo City Terminal Light"
 author: "Michaël Ball"
+variant: "light"
 palette:
   base00: "FBFBFD"
   base01: "F6F6F8"

--- a/base16/tokyo-night-dark.yaml
+++ b/base16/tokyo-night-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo Night Dark"
 author: "Michaël Ball"
+variant: "dark"
 palette:
   base00: "1A1B26"
   base01: "16161E"

--- a/base16/tokyo-night-light.yaml
+++ b/base16/tokyo-night-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo Night Light"
 author: "Michaël Ball"
+variant: "light"
 palette:
   base00: "D5D6DB"
   base01: "CBCCD1"

--- a/base16/tokyo-night-storm.yaml
+++ b/base16/tokyo-night-storm.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo Night Storm"
 author: "Michaël Ball"
+variant: "dark"
 palette:
   base00: "24283B"
   base01: "16161E"

--- a/base16/tokyo-night-terminal-dark.yaml
+++ b/base16/tokyo-night-terminal-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo Night Terminal Dark"
 author: "Michaël Ball"
+variant: "dark"
 palette:
   base00: "16161E"
   base01: "1A1B26"

--- a/base16/tokyo-night-terminal-light.yaml
+++ b/base16/tokyo-night-terminal-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo Night Terminal Light"
 author: "Michaël Ball"
+variant: "light"
 palette:
   base00: "D5D6DB"
   base01: "CBCCD1"

--- a/base16/tokyo-night-terminal-storm.yaml
+++ b/base16/tokyo-night-terminal-storm.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyo Night Terminal Storm"
 author: "Michaël Ball"
+variant: "dark"
 palette:
   base00: "24283B"
   base01: "1A1B26"

--- a/base16/tokyodark-terminal.yaml
+++ b/base16/tokyodark-terminal.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyodark Terminal"
 author: "Tiagovla (https://github.com/tiagovla/)"
+variant: "dark"
 palette:
   base00: "11121d"
   base01: "1A1B2A"

--- a/base16/tokyodark.yaml
+++ b/base16/tokyodark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tokyodark"
 author: "Tiagovla (https://github.com/tiagovla/)"
+variant: "dark"
 palette:
   base00: "11121d"
   base01: "151621"

--- a/base16/tomorrow-night-eighties.yaml
+++ b/base16/tomorrow-night-eighties.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tomorrow Night Eighties"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "2d2d2d"
   base01: "393939"

--- a/base16/tomorrow-night.yaml
+++ b/base16/tomorrow-night.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tomorrow Night"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "dark"
 palette:
   base00: "1d1f21"
   base01: "282a2e"

--- a/base16/tomorrow.yaml
+++ b/base16/tomorrow.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Tomorrow"
 author: "Chris Kempson (http://chriskempson.com)"
+variant: "light"
 palette:
   base00: "ffffff"
   base01: "e0e0e0"

--- a/base16/tube.yaml
+++ b/base16/tube.yaml
@@ -3,6 +3,7 @@ system: "base16"
 name: "London Tube"
 slug: "tube"
 author: "Jan T. Sott"
+variant: "dark"
 palette:
   base00: "231f20" # ----
   base01: "1c3f95" # ---

--- a/base16/twilight.yaml
+++ b/base16/twilight.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Twilight"
 author: "David Hart (https://github.com/hartbit)"
+variant: "dark"
 palette:
   base00: "1e1e1e"
   base01: "323537"

--- a/base16/unikitty-dark.yaml
+++ b/base16/unikitty-dark.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Unikitty Dark"
 author: "Josh W Lewis (@joshwlewis)"
+variant: "dark"
 palette:
   base00: "2e2a31"
   base01: "4a464d"

--- a/base16/unikitty-light.yaml
+++ b/base16/unikitty-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Unikitty Light"
 author: "Josh W Lewis (@joshwlewis)"
+variant: "light"
 palette:
   base00: "ffffff"
   base01: "e1e1e2"

--- a/base16/unikitty-reversible.yaml
+++ b/base16/unikitty-reversible.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Unikitty Reversible"
 author: "Josh W Lewis (@joshwlewis)"
+variant: "dark"
 palette:
   base00: "2e2a31"
   base01: "4b484e"

--- a/base16/uwunicorn.yaml
+++ b/base16/uwunicorn.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "UwUnicorn"
 author: "Fernando Marques (https://github.com/RakkiUwU) and Gabriel Fontes (https://github.com/Misterio77)"
+variant: "dark"
 palette:
   base00: "241b26"
   base01: "2f2a3f"

--- a/base16/vice.yaml
+++ b/base16/vice.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "vice"
 author: "Thomas Leon Highbaugh thighbaugh@zoho.com"
+variant: "dark"
 palette:
   base00: "17191E"
   base01: "22262d"

--- a/base16/vulcan.yaml
+++ b/base16/vulcan.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "vulcan"
 author: "Andrey Varfolomeev"
+variant: "dark"
 palette:
   base00: "041523"
   base01: "122339"

--- a/base16/windows-10-light.yaml
+++ b/base16/windows-10-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Windows 10 Light"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "light"
 palette:
   base00: "f2f2f2" # bright white
   base01: "e5e5e5" # brightish white

--- a/base16/windows-10.yaml
+++ b/base16/windows-10.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Windows 10"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "dark"
 palette:
   base00: "0c0c0c" # black
   base01: "2f2f2f" # darkish black

--- a/base16/windows-95-light.yaml
+++ b/base16/windows-95-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Windows 95 Light"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "light"
 palette:
   base00: "fcfcfc" # bright white
   base01: "e0e0e0" # brightish white

--- a/base16/windows-95.yaml
+++ b/base16/windows-95.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Windows 95"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "dark"
 palette:
   base00: "000000" # black
   base01: "1C1C1C" # darkish black

--- a/base16/windows-highcontrast-light.yaml
+++ b/base16/windows-highcontrast-light.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Windows High Contrast Light"
 slug: "windows-highcontrast-light"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "light"
 palette:
   base00: "fcfcfc" # bright white
   base01: "e8e8e8" # brightish white

--- a/base16/windows-highcontrast.yaml
+++ b/base16/windows-highcontrast.yaml
@@ -2,6 +2,7 @@ system: "base16"
 name: "Windows High Contrast"
 slug: "windows-highcontrast"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "dark"
 palette:
   base00: "000000" # black
   base01: "1C1C1C" # darkish black

--- a/base16/windows-nt-light.yaml
+++ b/base16/windows-nt-light.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Windows NT Light"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "light"
 palette:
   base00: "ffffff" # bright white
   base01: "eaeaea" # brightish white

--- a/base16/windows-nt.yaml
+++ b/base16/windows-nt.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Windows NT"
 author: "Fergus Collins (https://github.com/C-Fergus)"
+variant: "dark"
 palette:
   base00: "000000" # black
   base01: "2a2a2a" # darkish black

--- a/base16/woodland.yaml
+++ b/base16/woodland.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Woodland"
 author: "Jay Cornwall (https://jcornwall.com)"
+variant: "dark"
 palette:
   base00: "231e18"
   base01: "302b25"

--- a/base16/xcode-dusk.yaml
+++ b/base16/xcode-dusk.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "XCode Dusk"
 author: "Elsa Gonsiorowski (https://github.com/gonsie)"
+variant: "dark"
 palette:
   base00: "282B35"
   base01: "3D4048"

--- a/base16/zenbones.yaml
+++ b/base16/zenbones.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Zenbones"
 author: "mcchrish"
+variant: "dark"
 palette:
   base00: "191919"
   base01: "DE6E7C"

--- a/base16/zenburn.yaml
+++ b/base16/zenburn.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Zenburn"
 author: "elnawe"
+variant: "dark"
 palette:
   base00: "383838"
   base01: "404040"


### PR DESCRIPTION
Add dark/light variant value to schemes. I want to have the builder build vscode themes, but it can't unless the schemes contain the `variant`.