### PR TITLE
Add 'moonlight' scheme

### DIFF
--- a/base16/moonlight.yaml
+++ b/base16/moonlight.yaml
@@ -1,0 +1,23 @@
+# base16 port of the Moonlight color scheme, originally for VSCode.
+# Ported from the Neovim version (https://github.com/shaunsingh/moonlight.nvim).
+system: "base16"
+name: "Moonlight"
+author: "Jeremy Swinarton (https://github.com/jswinarton)"
+variant: "dark"
+palette:
+  base00: "212337"
+  base01: "403c64"
+  base02: "596399"
+  base03: "748cd6"
+  base04: "a1abe0"
+  base05: "a3ace1"
+  base06: "b4a4f4"
+  base07: "ef43fa"
+  base08: "ff5370"
+  base09: "f67f81"
+  base0A: "ffc777"
+  base0B: "2df4c0"
+  base0D: "40ffff"
+  base0C: "04d1f9"
+  base0E: "b994f1"
+  base0F: "ecb2f0"


### PR DESCRIPTION
This PR adds a base16 version of the popular [moonlight](https://github.com/atomiks/moonlight-vscode-theme) color scheme originally created for VSCode.