### PR TITLE
Auto assign admins to issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tinted-theming/schemes

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,18 @@
+name: Auto assignment for issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: 'Auto-assign issue'
+        uses: pozil/auto-assign-issue@v2
+        with:
+          repo-token: ${{ secrets.BOT_ACCESS_TOKEN }}
+          teams: schemes
+          numOfAssignee: 3


### PR DESCRIPTION
Add codeowners so maintainers are automatically tagged to PRs and add action to auto assign `@tinted-theming/schemes` group to issues.