### PR TITLE
Add gallery links to readme scheme variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Scheme families:
 
-- [base16]
-- [base24]
+- [base16] ([gallery](https://tinted-theming.github.io/base16-gallery/))
+- [base24] ([gallery](https://nico-i.github.io/scheme-viewer/base24/))
 
 ## Contributing
 


### PR DESCRIPTION
@nico-i created a gallery for base16 and base24. While we have a gallery for base16, we don't yet have one for base24 so I've put links to both in the readme. Related to: https://github.com/tinted-theming/schemes/issues/22