### PR TITLE
align everforest colors with other themes and shells

### DIFF
--- a/base16/everforest-dark-hard.yaml
+++ b/base16/everforest-dark-hard.yaml
@@ -1,21 +1,21 @@
 system: "base16"
 name: "Everforest Dark Hard"
-author: "Oskar Liew (https://github.com/OskarLiew)"
+author: "Sainnhe Park (https://github.com/sainnhe)"
 variant: "dark"
 palette:
-  base00: "272e33" # bg0,        Default background
-  base01: "2e383c" # bg1,        Lighter background
-  base02: "414b50" # bg3,        Selection background
-  base03: "859289" # grey1,      Comments
-  base04: "9da9a0" # grey2,      Dark foreground
-  base05: "d3c6aa" # fg,         Default foreground
-  base06: "e4e1cd" # bg3,        Light foreground
-  base07: "fdf6e3" # bg0,        Light background
-  base08: "7fbbb3" # blue
-  base09: "d699b6" # purple
-  base0A: "dbbc7f" # yellow
-  base0B: "83c092" # aqua
-  base0C: "e69875" # orange
-  base0D: "a7c080" # green
-  base0E: "e67e80" # red
-  base0F: "4C3743" # bg_visual
+  base00: "272e33" # bg0,       palette1 dark
+  base01: "2e383c" # bg1,       palette1 dark
+  base02: "414b50" # bg3,       palette1 dark
+  base03: "859289" # grey1,     palette2 dark
+  base04: "9da9a0" # grey2,     palette2 dark
+  base05: "d3c6aa" # fg,        palette2 dark
+  base06: "edeada" # bg3,       palette1 light
+  base07: "fffbef" # bg0,       palette1 light
+  base08: "e67e80" # red,       palette2 dark
+  base09: "e69875" # orange,    palette2 dark
+  base0A: "dbbc7f" # yellow,    palette2 dark
+  base0B: "a7c080" # green,     palette2 dark
+  base0C: "83c092" # aqua,      palette2 dark
+  base0D: "7fbbb3" # blue,      palette2 dark
+  base0E: "d699b6" # purple,    palette2 dark
+  base0F: "9da9a0" # grey2,     palette2 dark

--- a/base16/everforest.yaml
+++ b/base16/everforest.yaml
@@ -3,19 +3,19 @@ name: "Everforest"
 author: "Sainnhe Park (https://github.com/sainnhe)"
 variant: "dark"
 palette:
-  base00: "2f383e" # bg0,       palette1 dark (medium)
-  base01: "374247" # bg1,       palette1 dark (medium)
-  base02: "4a555b" # bg3,       palette1 dark (medium)
+  base00: "2d353b" # bg0,       palette1 dark
+  base01: "343f44" # bg1,       palette1 dark
+  base02: "475258" # bg3,       palette1 dark
   base03: "859289" # grey1,     palette2 dark
   base04: "9da9a0" # grey2,     palette2 dark
   base05: "d3c6aa" # fg,        palette2 dark
-  base06: "e4e1cd" # bg3,       palette1 light (medium)
-  base07: "fdf6e3" # bg0,       palette1 light (medium)
-  base08: "7fbbb3" # blue,      palette2 dark
-  base09: "d699b6" # purple,    palette2 dark
+  base06: "e6e2cc" # bg3,       palette1 light
+  base07: "fdf6e3" # bg0,       palette1 light
+  base08: "e67e80" # red,       palette2 dark
+  base09: "e69875" # orange,    palette2 dark
   base0A: "dbbc7f" # yellow,    palette2 dark
-  base0B: "83c092" # aqua,      palette2 dark
-  base0C: "e69875" # orange,    palette2 dark
-  base0D: "a7c080" # green,     palette2 dark
-  base0E: "e67e80" # red,       palette2 dark
-  base0F: "eaedc8" # bg_visual, palette1 dark (medium)
+  base0B: "a7c080" # green,     palette2 dark
+  base0C: "83c092" # aqua,      palette2 dark
+  base0D: "7fbbb3" # blue,      palette2 dark
+  base0E: "d699b6" # purple,    palette2 dark
+  base0F: "9da9a0" # grey2,     palette2 dark


### PR DESCRIPTION
hi.

current Everforest colors assignment differs a lot from both Everforest palette's intentions https://github.com/sainnhe/everforest/blob/master/palette.md and screenshots https://github.com/sainnhe/everforest/blob/master/README.md

this leads eg to partially unusable theme in tinted-shell https://github.com/tinted-theming/tinted-shell/blob/0c0cc5b7d262136a8598384d00f882b49464eb07/scripts/base16-everforest.sh#L8 - color00 is the same as color_background, causing inline shell comments to be invisible (try typing eg `% true # this is comment` - you'll see only cmd)

in this pr i align color assingments with other themes in which green is green etc. for instance i've fixed (git) diff adds/removals to be red/green instead of blue/aqua (as they should be according to both tinted-theming & Everforest guidelines). 

proper shell coloring is present eg in Gogh [here](https://github.com/Gogh-Co/Gogh/blob/3b17aa93212512d7eafc24aca23b27db58ae02fe/installs/everforest-dark-medium.sh#L6-L11) (at least `COLOR_02..COLOR_07`) and looks as expected - so i took those into account too (there's ongoing work to rebase Gogh onto tinted-theming schemes)