### PR TITLE
Remove multilines from meta info

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,6 @@ rules:
   document-start: disable
   comments: disable
   line-length:
-    max: 120
+    max: 180
     level: error
     allow-non-breakable-inline-mappings: true

--- a/base16/papercolor-dark.yaml
+++ b/base16/papercolor-dark.yaml
@@ -1,8 +1,6 @@
 system: "base16"
 name: "PaperColor Dark"
-author: |
-  Jon Leopard (http://github.com/jonleopard)
-  based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
+author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 variant: "dark"
 palette:
   base00: "1c1c1c" # Default Background

--- a/base16/papercolor-light.yaml
+++ b/base16/papercolor-light.yaml
@@ -1,8 +1,6 @@
 system: "base16"
 name: "PaperColor Light"
-author: |
-  Jon Leopard (http://github.com/jonleopard)
-  based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
+author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 variant: "light"
 palette:
   base00: "eeeeee" # Default Background

--- a/base16/shades-of-purple.yaml
+++ b/base16/shades-of-purple.yaml
@@ -1,8 +1,6 @@
 system: "base16"
 name: "Shades of Purple"
-author: |
-  Iolar Demartini Junior (http://github.com/demartini
-  based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode).
+author: Iolar Demartini Junior (http://github.com/demartini), based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode)
 variant: "dark"
 palette:
   base00: "1e1e3f" # default background

--- a/base16/snazzy.yaml
+++ b/base16/snazzy.yaml
@@ -1,8 +1,6 @@
 system: "base16"
 name: "Snazzy"
-author: |
-  Chawye Hsu (https://github.com/chawyehsu)
-  based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
+author: Chawye Hsu (https://github.com/chawyehsu), based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
 variant: "dark"
 palette:
   base00: "282a36"

--- a/base16/spaceduck.yaml
+++ b/base16/spaceduck.yaml
@@ -1,8 +1,6 @@
 system: "base16"
 name: "Spaceduck"
-author: |
-  Guillermo Rodriguez (https://github.com/pineapplegiant),
-  packaged by Gabriel Fontes (https://github.com/Misterio77)
+author: Guillermo Rodriguez (https://github.com/pineapplegiant), packaged by Gabriel Fontes (https://github.com/Misterio77)
 variant: "dark"
 palette:
   base00: "16172d"


### PR DESCRIPTION
There is an issue with how mustache multiline text is used in templates. The easiest way to fix this for now is to remove multiline text from schemes.

https://github.com/tinted-theming/tinted-builder-rust/issues/6