### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This will make it so that newlines and indents are to the scheme standard if you have the editor config plugin installed in your IDE.

https://editorconfig.org