### PR TITLE
UPDATE: tinted-theming gallery links in various README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Scheme families:
 
-- [base16] ([gallery](https://tinted-theming.github.io/tinted-gallery/))
-- [base24] ([gallery](https://nico-i.github.io/scheme-viewer/base24/))
+- [base16 & base24] ([gallery](https://tinted-theming.github.io/tinted-gallery/))
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scheme families:
 
-- [base16] ([gallery](https://tinted-theming.github.io/base16-gallery/))
+- [base16] ([gallery](https://nico-i.github.io/scheme-viewer/base16/))
 - [base24] ([gallery](https://nico-i.github.io/scheme-viewer/base24/))
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scheme families:
 
-- [base16] ([gallery](https://nico-i.github.io/scheme-viewer/base16/))
+- [base16] ([gallery](https://tinted-theming.github.io/tinted-gallery/))
 - [base24] ([gallery](https://nico-i.github.io/scheme-viewer/base24/))
 
 ## Contributing

--- a/base16/README.md
+++ b/base16/README.md
@@ -1,7 +1,7 @@
 # base16
 
 Have a look at the
-[Gallery](https://nico-i.github.io/scheme-viewer/base16/) to preview these colorschemes.
+[Gallery](https://tinted-theming.github.io/tinted-gallery/) to preview these colorschemes.
 
 ## Imported Scheme Repositories
 

--- a/base16/README.md
+++ b/base16/README.md
@@ -1,7 +1,7 @@
 # base16
 
 Have a look at the
-[Gallery](https://tinted-theming.github.io/base16-gallery/) to preview these colorschemes.
+[Gallery](https://nico-i.github.io/scheme-viewer/base16/) to preview these colorschemes.
 
 ## Imported Scheme Repositories
 


### PR DESCRIPTION
Base16 gallery link was broken. Updated to align with working base24 gallery domain, for base16 gallery page.