### PR TITLE
Fixes Brushtrees being marked as dark despite being a light theme

### DIFF
--- a/base16/brushtrees.yaml
+++ b/base16/brushtrees.yaml
@@ -2,7 +2,7 @@ system: "base16"
 name: "Brush Trees"
 slug: "brushtrees"
 author: "Abraham White <abelincoln.white@gmail.com>"
-variant: "dark"
+variant: "light"
 palette:
   base00: "#E3EFEF"
   base01: "#C9DBDC"


### PR DESCRIPTION
Base brushtrees is a light theme with a brushtrees-dark variant, but both are marked as dark.