### PR TITLE
Add slugs to Rose Pine themes

### DIFF
--- a/base16/rose-pine-dawn.yaml
+++ b/base16/rose-pine-dawn.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Rosé Pine Dawn"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+slug: "rose-pine-dawn"
 variant: "light"
 palette:
   base00: "#faf4ed"

--- a/base16/rose-pine-moon.yaml
+++ b/base16/rose-pine-moon.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Rosé Pine Moon"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+slug: "rose-pine-moon"
 variant: "dark"
 palette:
   base00: "#232136"

--- a/base16/rose-pine.yaml
+++ b/base16/rose-pine.yaml
@@ -1,6 +1,7 @@
 system: "base16"
 name: "Rosé Pine"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+slug: "rose-pine"
 variant: "dark"
 palette:
   base00: "#191724"


### PR DESCRIPTION
Because of the accent above the e in "Rose", the slugs were generated as "ros-pine" which is confusing when using the themes in scripting. This commit simply adds explicit slugs for what one would expect them to be.

This does however introduce breaking changes for anything depending on the slugs being "ros-pine".