### PR TITLE
Ensure relevant scheme-system exists in yaml file

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -24,6 +24,11 @@ for scheme_system in $supported_schemes_systems; do
           exit 1
         fi
 
+        if ! grep -q "$scheme_system" "$scheme_path"; then
+          echo "Error: Scheme system "$scheme_system" value missing from file"
+          exit 1
+        fi
+
         if $(grep -q "base0.: \"[^#]" "$scheme_path"); then
           echo "Error: \"base0x\" palette property must begin with a hash (\"#\") in $scheme_path"
           exit 1


### PR DESCRIPTION
There was a bug where "base24" scheme-system was used in a base16 scheme (Fixed here https://github.com/tinted-theming/schemes/commit/c4672071e58a947fee17a548a682e443449ac27c) and the linting didn't pick it up, this change should fix that.