### PR TITLE
Fix scheme naming bug

### DIFF
--- a/base16/gruvbox-dark.yaml
+++ b/base16/gruvbox-dark.yaml
@@ -1,5 +1,5 @@
 system: "base16"
-name: "Gruvbox dark, medium"
+name: "Gruvbox dark"
 author: "Tinted Theming (https://github.com/tinted-theming), morhetz (https://github.com/morhetz/gruvbox)"
 variant: "dark"
 palette:


### PR DESCRIPTION
Fixes: https://github.com/tinted-theming/schemes/issues/53

`gruvbox-dark-medium.yaml` already exists so this causes a conflict