### PR TITLE
Fix various typos and name mismatches

### DIFF
--- a/base24/dark-plus.yaml
+++ b/base24/dark-plus.yaml
@@ -1,5 +1,5 @@
 system: "base24"
-name: "Dark+"
+name: "Dark Plus"
 author: "FredHappyface (https://github.com/fredHappyface)"
 variant: "dark"
 palette:

--- a/base24/medallion.yaml
+++ b/base24/medallion.yaml
@@ -1,5 +1,5 @@
 system: "base24"
-name: "Medailion"
+name: "Medallion"
 author: "FredHappyface (https://github.com/fredHappyface)"
 variant: "dark"
 palette:

--- a/base24/space-gray-eighties-dull.yaml
+++ b/base24/space-gray-eighties-dull.yaml
@@ -1,5 +1,5 @@
 system: "base24"
-name: "Space Grey Eighties Dull"
+name: "Space Gray Eighties Dull"
 author: "FredHappyface (https://github.com/fredHappyface)"
 variant: "dark"
 palette:

--- a/base24/space-gray-eighties.yaml
+++ b/base24/space-gray-eighties.yaml
@@ -1,5 +1,5 @@
 system: "base24"
-name: "Space Grey Eighties"
+name: "Space Gray Eighties"
 author: "FredHappyface (https://github.com/fredHappyface)"
 variant: "dark"
 palette:

--- a/base24/thayer-bright.yaml
+++ b/base24/thayer-bright.yaml
@@ -1,5 +1,5 @@
 system: "base24"
-name: "Thayler Bright"
+name: "Thayer Bright"
 author: "FredHappyface (https://github.com/fredHappyface)"
 variant: "dark"
 palette:


### PR DESCRIPTION
This fixes various mismatches between file names and `name` fields in schemes.
For ambiguous possibilities (e.g. "gray" vs "grey"), I went with the name from the original source of the schemes (https://github.com/Base24/base24-mbadolato-iterm2-color-schemes).

These mismatches were found while debugging the build script of https://github.com/tinted-theming/tinted-gallery in https://github.com/tinted-theming/tinted-gallery/issues/16