### PR TITLE
Add base16 Penumbra themes

### DIFF
--- a/base16/README.md
+++ b/base16/README.md
@@ -68,6 +68,7 @@ These are the original locations all schemes were imported from.
 * [Pandora](https://github.com/pandorasfox/base16-pandora-scheme) maintained by [pandorasfox](https://github.com/pandorasfox)
 * [PaperColor](https://github.com/jonleopard/base16-papercolor-scheme) maintained by [jonleopard](https://github.com/jonleopard)
 * [Pasque](https://github.com/Misterio77/base16-pasque-scheme) maintained by [Misterio77](https://github.com/Misterio77)
+* [Penumbra](https://github.com/nealmckee/penumbra) maintained by [Zachary Weiss](https://github.com/zacharyweiss)
 * [pinky](https://github.com/b3nj5m1n/base16-pinky-scheme) maintained by [b3nj5m1n](https://github.com/b3nj5m1n)
 * [Porple](https://github.com/AuditeMarlow/base16-porple-scheme) maintained by [AuditeMarlow](https://github.com/AuditeMarlow)
 * [Precious Themes](https://github.com/precious-themes/base16-precious-schemes) maintained by [precious-themes](https://github.com/precious-themes) ([4lex4](https://github.com/4lex4))

--- a/base16/penumbra-dark-contrast-plus-plus.yaml
+++ b/base16/penumbra-dark-contrast-plus-plus.yaml
@@ -1,0 +1,22 @@
+system: "base16"
+name: "Penumbra Dark Contrast Plus Plus"
+author: "Zachary Weiss (https://github.com/zacharyweiss)"
+variant: "dark"
+description: "A mathematically balanced colour scheme constructed in a perceptually uniform colour space, by Neal McKee. https://github.com/nealmckee/penumbra"
+palette:
+  base00: "#0D0F13" # shade-
+  base01: "#181B1F" # shade
+  base02: "#3E4044" # shade+
+  base03: "#636363" # sky-
+  base04: "#AEAEAE" # sky
+  base05: "#DEDEDE" # sky+
+  base06: "#FFF7ED" # sun
+  base07: "#FFFDFB" # sun+
+  base08: "#F58C81" # red
+  base09: "#E09F47" # orange
+  base0A: "#A9B852" # yellow
+  base0B: "#54C794" # green
+  base0C: "#00C4D7" # cyan
+  base0D: "#6EB2FD" # blue
+  base0E: "#B69CF6" # purple
+  base0F: "#E58CC5" # magenta

--- a/base16/penumbra-dark-contrast-plus.yaml
+++ b/base16/penumbra-dark-contrast-plus.yaml
@@ -1,0 +1,22 @@
+system: "base16"
+name: "Penumbra Dark Contrast Plus"
+author: "Zachary Weiss (https://github.com/zacharyweiss)"
+variant: "dark"
+description: "A mathematically balanced colour scheme constructed in a perceptually uniform colour space, by Neal McKee. https://github.com/nealmckee/penumbra"
+palette:
+  base00: "#181B1F" # shade-
+  base01: "#24272B" # shade
+  base02: "#3E4044" # shade+
+  base03: "#636363" # sky-
+  base04: "#9E9E9E" # sky
+  base05: "#CECECE" # sky+
+  base06: "#FFF7ED" # sun
+  base07: "#FFFDFB" # sun+
+  base08: "#DF7F78" # red
+  base09: "#CE9042" # orange
+  base0A: "#9CA748" # yellow
+  base0B: "#50B584" # green
+  base0C: "#00B3C2" # cyan
+  base0D: "#61A3E6" # blue
+  base0E: "#A48FE1" # purple
+  base0F: "#D080B6" # magenta

--- a/base16/penumbra-dark.yaml
+++ b/base16/penumbra-dark.yaml
@@ -1,0 +1,22 @@
+system: "base16"
+name: "Penumbra Dark"
+author: "Zachary Weiss (https://github.com/zacharyweiss)"
+variant: "dark"
+description: "A mathematically balanced colour scheme constructed in a perceptually uniform colour space, by Neal McKee. https://github.com/nealmckee/penumbra"
+palette:
+  base00: "#24272B" # shade-
+  base01: "#303338" # shade
+  base02: "#3E4044" # shade+
+  base03: "#636363" # sky-
+  base04: "#8F8F8F" # sky
+  base05: "#BEBEBE" # sky+
+  base06: "#FFF7ED" # sun
+  base07: "#FFFDFB" # sun+
+  base08: "#CA736C" # red
+  base09: "#BA823A" # orange
+  base0A: "#8D9741" # yellow
+  base0B: "#47A477" # green
+  base0C: "#00A2AF" # cyan
+  base0D: "#5794D0" # blue
+  base0E: "#9481CC" # purple
+  base0F: "#BC73A4" # magenta

--- a/base16/penumbra-light-contrast-plus-plus.yaml
+++ b/base16/penumbra-light-contrast-plus-plus.yaml
@@ -1,0 +1,22 @@
+system: "base16"
+name: "Penumbra Light Contrast Plus Plus"
+author: "Zachary Weiss (https://github.com/zacharyweiss)"
+variant: "light"
+description: "A mathematically balanced colour scheme constructed in a perceptually uniform colour space, by Neal McKee. https://github.com/nealmckee/penumbra"
+palette:
+  base00: "#FFFDFB" # sun+
+  base01: "#FFF7ED" # sun
+  base02: "#F2E6D4" # sun-
+  base03: "#DEDEDE" # sky+
+  base04: "#AEAEAE" # sky
+  base05: "#636363" # sky-
+  base06: "#181B1F" # shade
+  base07: "#0D0F13" # shade-
+  base08: "#F58C81" # red
+  base09: "#E09F47" # orange
+  base0A: "#A9B852" # yellow
+  base0B: "#54C794" # green
+  base0C: "#00C4D7" # cyan
+  base0D: "#6EB2FD" # blue
+  base0E: "#B69CF6" # purple
+  base0F: "#E58CC5" # magenta

--- a/base16/penumbra-light-contrast-plus.yaml
+++ b/base16/penumbra-light-contrast-plus.yaml
@@ -1,0 +1,22 @@
+system: "base16"
+name: "Penumbra Light Contrast Plus"
+author: "Zachary Weiss (https://github.com/zacharyweiss)"
+variant: "light"
+description: "A mathematically balanced colour scheme constructed in a perceptually uniform colour space, by Neal McKee. https://github.com/nealmckee/penumbra"
+palette:
+  base00: "#FFFDFB" # sun+
+  base01: "#FFF7ED" # sun
+  base02: "#F2E6D4" # sun-
+  base03: "#CECECE" # sky+
+  base04: "#9E9E9E" # sky
+  base05: "#636363" # sky-
+  base06: "#24272B" # shade
+  base07: "#181B1F" # shade-
+  base08: "#DF7F78" # red
+  base09: "#CE9042" # orange
+  base0A: "#9CA748" # yellow
+  base0B: "#50B584" # green
+  base0C: "#00B3C2" # cyan
+  base0D: "#61A3E6" # blue
+  base0E: "#A48FE1" # purple
+  base0F: "#D080B6" # magenta

--- a/base16/penumbra-light.yaml
+++ b/base16/penumbra-light.yaml
@@ -1,0 +1,22 @@
+system: "base16"
+name: "Penumbra Light"
+author: "Zachary Weiss (https://github.com/zacharyweiss)"
+variant: "light"
+description: "A mathematically balanced colour scheme constructed in a perceptually uniform colour space, by Neal McKee. https://github.com/nealmckee/penumbra"
+palette:
+  base00: "#FFFDFB" # sun+
+  base01: "#FFF7ED" # sun
+  base02: "#F2E6D4" # sun-
+  base03: "#BEBEBE" # sky+
+  base04: "#8F8F8F" # sky
+  base05: "#636363" # sky-
+  base06: "#303338" # shade
+  base07: "#24272B" # shade-
+  base08: "#CA736C" # red
+  base09: "#BA823A" # orange
+  base0A: "#8D9741" # yellow
+  base0B: "#47A477" # green
+  base0C: "#00A2AF" # cyan
+  base0D: "#5794D0" # blue
+  base0E: "#9481CC" # purple
+  base0F: "#BC73A4" # magenta


### PR DESCRIPTION
Howdy!

This PR adds Neal McKee's fantastic [Penumbra](https://github.com/nealmckee/penumbra) theme. Two things I want input on prior to merge:

1. Credit: Neal [welcomes ports](https://github.com/nealmckee/penumbra?tab=readme-ov-file#contributions) and the theme is MIT licensed. In this repo, it appears as though the "author" field is meant to indicate "maintainer" (/ "author of the yaml"), hence listing myself, but I don't wish to claim credit for the palette itself. I've added the source to the README and per-theme descriptions; is there a more appropriate way to do this? @nealmckee: if you see this, any input / preferences?
2. Naming: upstream, the contrast variants are labeled "contrast+" and "contrast++". Your `home` repo and other PRs here seems to indicate the yaml name should match the [slugified](https://github.com/tinted-theming/home/blob/main/builder.md#slugify) `name` field; I changed these variants to "Contrast Plus" and "Contrast Plus Plus" to conform. However this feels quite clunky/lengthy to me; any better alternative?