### PR TITLE
Fix #79 - Match official Dracula spec

### DIFF
--- a/base16/dracula.yaml
+++ b/base16/dracula.yaml
@@ -1,28 +1,45 @@
 system: "base16"
 name: "Dracula"
 author: "clach04 (https://github.com/clach04)"
-description: "based on https://spec.draculatheme.com/#sec-ANSI"
+description: "based on https://github.com/dracula/draculatheme.com/blob/main/content/spec.mdx"
 variant: "dark"
+# Subset of base24 Dracula
+# https://github.com/tinted-theming/base24/blob/main/styling.md
+# https://github.com/tinted-theming/home/blob/main/styling.md
+# https://github.com/chriskempson/base16/blob/main/styling.md
+# Typically expect order of base00-base07 (dark to light versus light to dark) to differ depending on variant
+# based on https://github.com/dracula/draculatheme.com/blob/main/content/spec.mdx
+# Straight mapping of ANSI values from specification as of 2026-03-29
+# Reference https://github.com/dracula/dracula-theme
+# From https://github.com/clach04/putty_themes/blob/master/raw_themes/dracula.tstk which is used as source for https://github.com/clach04/dracula_putty
+#TODO consider Purple for cursor
 palette:
-  base00: "#282a36"
-  base01: "#21222c"
-  base02: "#44475a"  # FIXME base24 uses this as ANSI Bright Black.. But text editors use this for Selection color - no clear solution here
-  base03: "#6272a4"  # Dracula AnsiBrightBlack
-  base04: "#9ea8c7"  # NOT a Dracula color!
-  base05: "#f8f8f2"  # Dracula AnsiWhite
-  base06: "#f0f1f4"  # NOT a Dracula color!# FIXME base24 uses this as ANSI White
-  base07: "#ffffff"
+  base00: "#282a36"  # Default Background  # Dracula Background
+  base01: "#21222c"  # Darker Background (Darkest Gray) (Used for status bars, line number and folding marks) # Dracula Background Dark / AnsiBlack
+  base02: "#44475A"  # Selection Background (Bright Black) # Dracula Selection
+  base03: "#6272a4"  # Comments, Invisibles, Line Highlighting (Grey) # Dracula Current Line / Comment / AnsiBrightBlack
+  base04: "#9ea8c7"  # Dark/Light Foreground (Used for status bars) (Light Grey) # NOT a Dracula color!
+  base05: "#f8f8f2"  # Default Foreground, Caret, Delimiters, Operators (Foreground) # Dracula Foreground / AnsiWhite
+  base06: "#f8f8f2"  # Dark Foreground (Not often used) (White)  # TODO review, currently same as above base05
+  base07: "#ffffff"  # Dark Background (Not often used) (Bright White) # Dracula AnsiBrightWhite
 
-  base08: "#ff5555"
-  base09: "#ffb86c"
-  base0A: "#f1fa8c"
-  base0B: "#50fa7b"
-  base0C: "#8be9fd"
-  base0D: "#bd93f9"
-  base0E: "#ff79c6"
-  base0F: "#993333"  # NOT a Dracula color! - this is a darker shaed of base08 - derived via https://www.color-hex.com/color/ff5555
+  # ANSI8 (without Black/White) + 2 (Orange + Dark Red/Brown)
+  base08: "#ff5555"  # Red
+  base09: "#FFB86C"  # Orange
+  base0A: "#f1fa8c"  # Yellow
+  base0B: "#50fa7b"  # Green
+  base0C: "#8be9fd"  # Aqua / Cyan
+  base0D: "#bd93f9"  # Blue
+  base0E: "#ff79c6"  # Purple / Magenta
+  base0F: "#993333"  # Dark Red or Brown, derive dark red from base08 - derived via https://www.color-hex.com/color/ff5555
 
-#based on https://spec.draculatheme.com/#sec-ANSI
-#Straight mapping of ANSI values from specification as of 2024 (last updated 2021)
-#Reference https://github.com/dracula/dracula-theme
-#Referencs https://github.com/dracula/spec/blob/master/dracula-spec.md
+  # ANSI16 Bright/Bold (without Black/White)
+  base10: "#1e2029"  # (Darker Black)	Darker Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
+  base11: "#16171d"  # (Darkest Black)	The Darkest Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
+  base12: "#ff6e6e"  # Bright Red
+  base13: "#ffffa5"  # Bright Yellow
+  base14: "#69ff94"  # Bright Green
+  base15: "#a4ffff"  # Bright Cyan
+  base16: "#d6acff"  # Bright Blue
+  base17: "#ff92df"  # Bright Magenta / Bright Purple
+

--- a/base16/dracula.yaml
+++ b/base16/dracula.yaml
@@ -22,7 +22,6 @@ palette:
   base05: "#f8f8f2"  # Default Foreground, Caret, Delimiters, Operators (Foreground) # Dracula Foreground / AnsiWhite
   base06: "#f8f8f2"  # Dark Foreground (Not often used) (White)  # TODO review, currently same as above base05
   base07: "#ffffff"  # Dark Background (Not often used) (Bright White) # Dracula AnsiBrightWhite
-
   # ANSI8 (without Black/White) + 2 (Orange + Dark Red/Brown)
   base08: "#ff5555"  # Red
   base09: "#FFB86C"  # Orange

--- a/base16/dracula.yaml
+++ b/base16/dracula.yaml
@@ -6,11 +6,11 @@ variant: "dark"
 palette:
   base00: "#282a36"
   base01: "#21222c"
-  base02: "#44475a"
-  base03: "#6272a4"
+  base02: "#44475a"  # FIXME base24 uses this as ANSI Bright Black.. But text editors use this for Selection color - no clear solution here
+  base03: "#6272a4"  # Dracula AnsiBrightBlack
   base04: "#9ea8c7"  # NOT a Dracula color!
-  base05: "#f8f8f2"
-  base06: "#f0f1f4"  # NOT a Dracula color!
+  base05: "#f8f8f2"  # Dracula AnsiWhite
+  base06: "#f0f1f4"  # NOT a Dracula color!# FIXME base24 uses this as ANSI White
   base07: "#ffffff"
 
   base08: "#ff5555"

--- a/base16/dracula.yaml
+++ b/base16/dracula.yaml
@@ -9,10 +9,6 @@ variant: "dark"
 # https://github.com/chriskempson/base16/blob/main/styling.md
 # Typically expect order of base00-base07 (dark to light versus light to dark) to differ depending on variant
 # based on https://github.com/dracula/draculatheme.com/blob/main/content/spec.mdx
-# Straight mapping of ANSI values from specification as of 2026-03-29
-# Reference https://github.com/dracula/dracula-theme
-# From https://github.com/clach04/putty_themes/blob/master/raw_themes/dracula.tstk which is used as source for https://github.com/clach04/dracula_putty
-#TODO consider Purple for cursor
 palette:
   base00: "#282a36"  # Default Background  # Dracula Background
   base01: "#21222c"  # Darker Background (Darkest Gray) (Used for status bars, line number and folding marks) # Dracula Background Dark / AnsiBlack

--- a/base16/dracula.yaml
+++ b/base16/dracula.yaml
@@ -1,21 +1,28 @@
 system: "base16"
 name: "Dracula"
-author: "Jamy Golden (http://github.com/JamyGolden), based on Dracula Theme (http://github.com/dracula)"
+author: "clach04 (https://github.com/clach04)"
+description: "based on https://spec.draculatheme.com/#sec-ANSI"
 variant: "dark"
 palette:
   base00: "#282a36"
-  base01: "#363447"
+  base01: "#21222c"
   base02: "#44475a"
   base03: "#6272a4"
-  base04: "#9ea8c7"
+  base04: "#9ea8c7"  # NOT a Dracula color!
   base05: "#f8f8f2"
-  base06: "#f0f1f4"
+  base06: "#f0f1f4"  # NOT a Dracula color!
   base07: "#ffffff"
+
   base08: "#ff5555"
   base09: "#ffb86c"
   base0A: "#f1fa8c"
   base0B: "#50fa7b"
   base0C: "#8be9fd"
-  base0D: "#80bfff"
+  base0D: "#bd93f9"
   base0E: "#ff79c6"
-  base0F: "#bd93f9"
+  base0F: "#993333"  # NOT a Dracula color! - this is a darker shaed of base08 - derived via https://www.color-hex.com/color/ff5555
+
+#based on https://spec.draculatheme.com/#sec-ANSI
+#Straight mapping of ANSI values from specification as of 2024 (last updated 2021)
+#Reference https://github.com/dracula/dracula-theme
+#Referencs https://github.com/dracula/spec/blob/master/dracula-spec.md

--- a/base16/dracula.yaml
+++ b/base16/dracula.yaml
@@ -32,14 +32,3 @@ palette:
   base0D: "#bd93f9"  # Blue
   base0E: "#ff79c6"  # Purple / Magenta
   base0F: "#993333"  # Dark Red or Brown, derive dark red from base08 - derived via https://www.color-hex.com/color/ff5555
-
-  # ANSI16 Bright/Bold (without Black/White)
-  base10: "#1e2029"  # (Darker Black)	Darker Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
-  base11: "#16171d"  # (Darkest Black)	The Darkest Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
-  base12: "#ff6e6e"  # Bright Red
-  base13: "#ffffa5"  # Bright Yellow
-  base14: "#69ff94"  # Bright Green
-  base15: "#a4ffff"  # Bright Cyan
-  base16: "#d6acff"  # Bright Blue
-  base17: "#ff92df"  # Bright Magenta / Bright Purple
-

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -8,10 +8,6 @@ variant: "dark"
 # https://github.com/chriskempson/base16/blob/main/styling.md
 # Typically expect order of base00-base07 (dark to light versus light to dark) to differ depending on variant
 # based on https://github.com/dracula/draculatheme.com/blob/main/content/spec.mdx
-# Straight mapping of ANSI values from specification as of 2026-03-29
-# Reference https://github.com/dracula/dracula-theme
-# From https://github.com/clach04/putty_themes/blob/master/raw_themes/dracula.tstk which is used as source for https://github.com/clach04/dracula_putty
-#TODO consider Purple for cursor
 palette:
   base00: "#282a36"  # Default Background  # Dracula Background
   base01: "#21222c"  # Darker Background (Darkest Gray) (Used for status bars, line number and folding marks) # Dracula Background Dark / AnsiBlack

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -6,11 +6,11 @@ variant: "dark"
 palette:
   base00: "#282a36"
   base01: "#21222c"
-  base02: "#44475a"
-  base03: "#6272a4"
+  base02: "#44475a"  # FIXME base24 uses this as ANSI Bright Black.. But text editors use this for Selection color - no clear solution here
+  base03: "#6272a4"  # Dracula AnsiBrightBlack
   base04: "#9ea8c7"  # NOT a Dracula color!
-  base05: "#f8f8f2"
-  base06: "#f0f1f4"  # NOT a Dracula color!
+  base05: "#f8f8f2"  # Dracula AnsiWhite
+  base06: "#f0f1f4"  # NOT a Dracula color!# FIXME base24 uses this as ANSI White
   base07: "#ffffff"
 
   base08: "#ff5555"

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -31,7 +31,7 @@ palette:
   base0E: "#ff79c6"  # Purple / Magenta
   base0F: "#993333"  # Dark Red or Brown, derive dark red from base08 - derived via https://www.color-hex.com/color/ff5555
   # ANSI16 Bright/Bold (without Black/White)
-  base10: "#1e2029"  # (Darker Black)	Darker Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
+  base10: "#1e2029"  # (Darker Black)	Darker Background - NOT a Dracula color!
   base11: "#16171d"  # (Darkest Black)	The Darkest Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
   base12: "#ff6e6e"  # Bright Red
   base13: "#ffffa5"  # Bright Yellow

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -32,7 +32,7 @@ palette:
   base0F: "#993333"  # Dark Red or Brown, derive dark red from base08 - derived via https://www.color-hex.com/color/ff5555
   # ANSI16 Bright/Bold (without Black/White)
   base10: "#1e2029"  # (Darker Black)	Darker Background - NOT a Dracula color!
-  base11: "#16171d"  # (Darkest Black)	The Darkest Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
+  base11: "#16171d"  # (Darkest Black)	The Darkest Background - NOT a Dracula color!
   base12: "#ff6e6e"  # Bright Red
   base13: "#ffffa5"  # Bright Yellow
   base14: "#69ff94"  # Bright Green

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -39,4 +39,3 @@ palette:
   base15: "#a4ffff"  # Bright Cyan
   base16: "#d6acff"  # Bright Blue
   base17: "#ff92df"  # Bright Magenta / Bright Purple
-

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -21,7 +21,6 @@ palette:
   base05: "#f8f8f2"  # Default Foreground, Caret, Delimiters, Operators (Foreground) # Dracula Foreground / AnsiWhite
   base06: "#f8f8f2"  # Dark Foreground (Not often used) (White)  # TODO review, currently same as above base05
   base07: "#ffffff"  # Dark Background (Not often used) (Bright White) # Dracula AnsiBrightWhite
-
   # ANSI8 (without Black/White) + 2 (Orange + Dark Red/Brown)
   base08: "#ff5555"  # Red
   base09: "#FFB86C"  # Orange
@@ -31,7 +30,6 @@ palette:
   base0D: "#bd93f9"  # Blue
   base0E: "#ff79c6"  # Purple / Magenta
   base0F: "#993333"  # Dark Red or Brown, derive dark red from base08 - derived via https://www.color-hex.com/color/ff5555
-
   # ANSI16 Bright/Bold (without Black/White)
   base10: "#1e2029"  # (Darker Black)	Darker Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
   base11: "#16171d"  # (Darkest Black)	The Darkest Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -1,37 +1,44 @@
 system: "base24"
 name: "Dracula"
 author: "clach04 (https://github.com/clach04)"
-description: "based on https://spec.draculatheme.com/#sec-ANSI"
+description: "based on https://github.com/dracula/draculatheme.com/blob/main/content/spec.mdx"
 variant: "dark"
+# https://github.com/tinted-theming/base24/blob/main/styling.md
+# https://github.com/tinted-theming/home/blob/main/styling.md
+# https://github.com/chriskempson/base16/blob/main/styling.md
+# Typically expect order of base00-base07 (dark to light versus light to dark) to differ depending on variant
+# based on https://github.com/dracula/draculatheme.com/blob/main/content/spec.mdx
+# Straight mapping of ANSI values from specification as of 2026-03-29
+# Reference https://github.com/dracula/dracula-theme
+# From https://github.com/clach04/putty_themes/blob/master/raw_themes/dracula.tstk which is used as source for https://github.com/clach04/dracula_putty
+#TODO consider Purple for cursor
 palette:
-  base00: "#282a36"
-  base01: "#21222c"
-  base02: "#44475a"  # FIXME base24 uses this as ANSI Bright Black.. But text editors use this for Selection color - no clear solution here
-  base03: "#6272a4"  # Dracula AnsiBrightBlack
-  base04: "#9ea8c7"  # NOT a Dracula color!
-  base05: "#f8f8f2"  # Dracula AnsiWhite
-  base06: "#f0f1f4"  # NOT a Dracula color!# FIXME base24 uses this as ANSI White
-  base07: "#ffffff"
+  base00: "#282a36"  # Default Background  # Dracula Background
+  base01: "#21222c"  # Darker Background (Darkest Gray) (Used for status bars, line number and folding marks) # Dracula Background Dark / AnsiBlack
+  base02: "#44475A"  # Selection Background (Bright Black) # Dracula Selection
+  base03: "#6272a4"  # Comments, Invisibles, Line Highlighting (Grey) # Dracula Current Line / Comment / AnsiBrightBlack
+  base04: "#9ea8c7"  # Dark/Light Foreground (Used for status bars) (Light Grey) # NOT a Dracula color!
+  base05: "#f8f8f2"  # Default Foreground, Caret, Delimiters, Operators (Foreground) # Dracula Foreground / AnsiWhite
+  base06: "#f8f8f2"  # Dark Foreground (Not often used) (White)  # TODO review, currently same as above base05
+  base07: "#ffffff"  # Dark Background (Not often used) (Bright White) # Dracula AnsiBrightWhite
 
-  base08: "#ff5555"
-  base09: "#ffb86c"
-  base0A: "#f1fa8c"
-  base0B: "#50fa7b"
-  base0C: "#8be9fd"
-  base0D: "#bd93f9"
-  base0E: "#ff79c6"
-  base0F: "#993333"  # NOT a Dracula color! - this is a darker shaed of base08 - derived via https://www.color-hex.com/color/ff5555
+  # ANSI8 (without Black/White) + 2 (Orange + Dark Red/Brown)
+  base08: "#ff5555"  # Red
+  base09: "#FFB86C"  # Orange
+  base0A: "#f1fa8c"  # Yellow
+  base0B: "#50fa7b"  # Green
+  base0C: "#8be9fd"  # Aqua / Cyan
+  base0D: "#bd93f9"  # Blue
+  base0E: "#ff79c6"  # Purple / Magenta
+  base0F: "#993333"  # Dark Red or Brown, derive dark red from base08 - derived via https://www.color-hex.com/color/ff5555
 
-  base10: "#1e2029"  # NOT a Dracula color! - Consider using something in range base00-07
-  base11: "#16171d"  # NOT a Dracula color! - Consider using something in range base00-07
-  base12: "#ff6e6e"
-  base13: "#ffffa5"
-  base14: "#69ff94"
-  base15: "#a4ffff"
-  base16: "#d6acff"
-  base17: "#ff92df"
+  # ANSI16 Bright/Bold (without Black/White)
+  base10: "#1e2029"  # (Darker Black)	Darker Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
+  base11: "#16171d"  # (Darkest Black)	The Darkest Background - NOT a Dracula color! - Consider using something in range base00-07 or deriving based on base00
+  base12: "#ff6e6e"  # Bright Red
+  base13: "#ffffa5"  # Bright Yellow
+  base14: "#69ff94"  # Bright Green
+  base15: "#a4ffff"  # Bright Cyan
+  base16: "#d6acff"  # Bright Blue
+  base17: "#ff92df"  # Bright Magenta / Bright Purple
 
-#based on https://spec.draculatheme.com/#sec-ANSI
-#Straight mapping of ANSI values from specification as of 2024 (last updated 2021)
-#Reference https://github.com/dracula/dracula-theme
-#Referencs https://github.com/dracula/spec/blob/master/dracula-spec.md

--- a/base24/dracula.yaml
+++ b/base24/dracula.yaml
@@ -1,29 +1,37 @@
 system: "base24"
 name: "Dracula"
-author: "FredHappyface (https://github.com/fredHappyface)"
+author: "clach04 (https://github.com/clach04)"
+description: "based on https://spec.draculatheme.com/#sec-ANSI"
 variant: "dark"
 palette:
   base00: "#282a36"
-  base01: "#363447"
+  base01: "#21222c"
   base02: "#44475a"
   base03: "#6272a4"
-  base04: "#9ea8c7"
+  base04: "#9ea8c7"  # NOT a Dracula color!
   base05: "#f8f8f2"
-  base06: "#f0f1f4"
+  base06: "#f0f1f4"  # NOT a Dracula color!
   base07: "#ffffff"
+
   base08: "#ff5555"
   base09: "#ffb86c"
   base0A: "#f1fa8c"
   base0B: "#50fa7b"
   base0C: "#8be9fd"
-  base0D: "#80bfff"
+  base0D: "#bd93f9"
   base0E: "#ff79c6"
-  base0F: "#bd93f9"
-  base10: "#1e2029"
-  base11: "#16171d"
-  base12: "#f28c8c"
-  base13: "#eef5a3"
-  base14: "#a3f5b8"
-  base15: "#baedf7"
-  base16: "#a3ccf5"
-  base17: "#f5a3d2"
+  base0F: "#993333"  # NOT a Dracula color! - this is a darker shaed of base08 - derived via https://www.color-hex.com/color/ff5555
+
+  base10: "#1e2029"  # NOT a Dracula color! - Consider using something in range base00-07
+  base11: "#16171d"  # NOT a Dracula color! - Consider using something in range base00-07
+  base12: "#ff6e6e"
+  base13: "#ffffa5"
+  base14: "#69ff94"
+  base15: "#a4ffff"
+  base16: "#d6acff"
+  base17: "#ff92df"
+
+#based on https://spec.draculatheme.com/#sec-ANSI
+#Straight mapping of ANSI values from specification as of 2024 (last updated 2021)
+#Reference https://github.com/dracula/dracula-theme
+#Referencs https://github.com/dracula/spec/blob/master/dracula-spec.md


### PR DESCRIPTION
Use official Dracula colors from:

  * https://github.com/dracula/draculatheme.com/blob/main/content/spec.mdx
  * https://spec.draculatheme.com/#sec-ANSI

NOTE base05 and base06 both map to `#f8f8f2`, which replaces `#f0f1f4` which is not in the official Dracula spec.