### PR TITLE
Updated charcoal-[dark,light] with new colors

### DIFF
--- a/base16/charcoal-dark.yaml
+++ b/base16/charcoal-dark.yaml
@@ -3,19 +3,19 @@ name: "Charcoal Dark"
 author: "Mubin Muhammad (https://github.com/mubin6th)"
 variant: "dark"
 palette:
-  base00: "#0f0b05",
-  base01: "#231b0e",
-  base02: "#2a2012",
-  base03: "#57462c",
-  base04: "#a88c62",
-  base05: "#c3a983",
-  base06: "#dec8a7",
-  base07: "#231b0e",
-  base08: "#a88c62",
-  base09: "#dec8a7",
-  base0A: "#dec8a7",
-  base0B: "#dec8a7",
-  base0C: "#dec8a7",
-  base0D: "#c3a983",
-  base0E: "#a88c62",
+  base00: "#0f0b05"
+  base01: "#231b0e"
+  base02: "#2a2012"
+  base03: "#57462c"
+  base04: "#a88c62"
+  base05: "#c3a983"
+  base06: "#dec8a7"
+  base07: "#231b0e"
+  base08: "#a88c62"
+  base09: "#dec8a7"
+  base0A: "#dec8a7"
+  base0B: "#dec8a7"
+  base0C: "#dec8a7"
+  base0D: "#c3a983"
+  base0E: "#a88c62"
   base0F: "#876e48"

--- a/base16/charcoal-dark.yaml
+++ b/base16/charcoal-dark.yaml
@@ -3,19 +3,19 @@ name: "Charcoal Dark"
 author: "Mubin Muhammad (https://github.com/mubin6th)"
 variant: "dark"
 palette:
-  base00: "#120f09"
-  base01: "#1e1812"
-  base02: "#35291d"
-  base03: "#66553f"
-  base04: "#a28662"
-  base05: "#c0a179"
-  base06: "#d6b891"
-  base07: "#292016"
-  base08: "#887254"
-  base09: "#d6b891"
-  base0A: "#c0a179"
-  base0B: "#927a60"
-  base0C: "#a28662"
-  base0D: "#d6b891"
-  base0E: "#a28662"
-  base0F: "#887254"
+  base00: "#0f0b05",
+  base01: "#231b0e",
+  base02: "#2a2012",
+  base03: "#57462c",
+  base04: "#a88c62",
+  base05: "#c3a983",
+  base06: "#dec8a7",
+  base07: "#231b0e",
+  base08: "#a88c62",
+  base09: "#dec8a7",
+  base0A: "#dec8a7",
+  base0B: "#dec8a7",
+  base0C: "#dec8a7",
+  base0D: "#c3a983",
+  base0E: "#a88c62",
+  base0F: "#876e48",

--- a/base16/charcoal-dark.yaml
+++ b/base16/charcoal-dark.yaml
@@ -18,4 +18,4 @@ palette:
   base0C: "#dec8a7",
   base0D: "#c3a983",
   base0E: "#a88c62",
-  base0F: "#876e48",
+  base0F: "#876e48"

--- a/base16/charcoal-light.yaml
+++ b/base16/charcoal-light.yaml
@@ -18,4 +18,4 @@ palette:
   base0C: "#110e06",
   base0D: "#251e0f",
   base0E: "#382e1b",
-  base0F: "#4b3e26",
+  base0F: "#4b3e26"

--- a/base16/charcoal-light.yaml
+++ b/base16/charcoal-light.yaml
@@ -3,19 +3,19 @@ name: "Charcoal Light"
 author: "Mubin Muhammad (https://github.com/mubin6th)"
 variant: "light"
 palette:
-  base00: "#cabda0",
-  base01: "#bcad8c",
-  base02: "#af9f7d",
-  base03: "#645538",
-  base04: "#110e06",
-  base05: "#382e1b",
-  base06: "#4b3e26",
-  base07: "#bcad8c",
-  base08: "#382e1b",
-  base09: "#110e06",
-  base0A: "#110e06",
-  base0B: "#110e06",
-  base0C: "#110e06",
-  base0D: "#251e0f",
-  base0E: "#382e1b",
+  base00: "#cabda0"
+  base01: "#bcad8c"
+  base02: "#af9f7d"
+  base03: "#645538"
+  base04: "#110e06"
+  base05: "#382e1b"
+  base06: "#4b3e26"
+  base07: "#bcad8c"
+  base08: "#382e1b"
+  base09: "#110e06"
+  base0A: "#110e06"
+  base0B: "#110e06"
+  base0C: "#110e06"
+  base0D: "#251e0f"
+  base0E: "#382e1b"
   base0F: "#4b3e26"

--- a/base16/charcoal-light.yaml
+++ b/base16/charcoal-light.yaml
@@ -3,19 +3,19 @@ name: "Charcoal Light"
 author: "Mubin Muhammad (https://github.com/mubin6th)"
 variant: "light"
 palette:
-  base00: "#d6b891"
-  base01: "#c0a179"
-  base02: "#a28662"
-  base03: "#887254"
-  base04: "#1e1812"
-  base05: "#35291d"
-  base06: "#413325"
-  base07: "#d6b891"
-  base08: "#413325"
-  base09: "#120f09"
-  base0A: "#292016"
-  base0B: "#120f09"
-  base0C: "#413325"
-  base0D: "#120f09"
-  base0E: "#292016"
-  base0F: "#66553f"
+  base00: "#cabda0",
+  base01: "#bcad8c",
+  base02: "#af9f7d",
+  base03: "#645538",
+  base04: "#110e06",
+  base05: "#382e1b",
+  base06: "#4b3e26",
+  base07: "#bcad8c",
+  base08: "#382e1b",
+  base09: "#110e06",
+  base0A: "#110e06",
+  base0B: "#110e06",
+  base0C: "#110e06",
+  base0D: "#251e0f",
+  base0E: "#382e1b",
+  base0F: "#4b3e26",


### PR DESCRIPTION
Charcoal is a warm colorscheme for text-editors, terminals, UI and more. The colorscheme resembles warm/rural weather, wheat field, afternoon sky etc. The dark background of Charcoal Dark is meant to help distinguish Code from UI. Charcoal is inspired by Gruvbox and Gruvbox Material colorschemes and tries to be simple and easy-on-eyes theme.

Charcoal was already added in #67, but it recently got updated with new, visibly more washed out colors, that are now included with this pull request.

<img width="1280" height="2048" alt="image" src="https://github.com/user-attachments/assets/436098fb-3c21-4438-afac-b010b5c8c11e" />
