### PR TITLE
fix: catppuccin variants colors base01-base04

### DIFF
--- a/base16/catppuccin-frappe.yaml
+++ b/base16/catppuccin-frappe.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#303446" # base
-  base01: "#292c3c" # mantle
-  base02: "#414559" # surface0
-  base03: "#51576d" # surface1
-  base04: "#626880" # surface2
+  base01: "#414559" # surface0
+  base02: "#51576d" # surface1
+  base03: "#737994" # overlay0
+  base04: "#a5adce" # subtext0
   base05: "#c6d0f5" # text
   base06: "#f2d5cf" # rosewater
   base07: "#babbf1" # lavender

--- a/base16/catppuccin-latte.yaml
+++ b/base16/catppuccin-latte.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "light"
 palette:
   base00: "#eff1f5" # base
-  base01: "#e6e9ef" # mantle
-  base02: "#ccd0da" # surface0
-  base03: "#bcc0cc" # surface1
-  base04: "#acb0be" # surface2
+  base01: "#ccd0da" # surface0
+  base02: "#bcc0cc" # surface1
+  base03: "#9ca0b0" # overlay0
+  base04: "#6c6f85" # subtext0
   base05: "#4c4f69" # text
   base06: "#dc8a78" # rosewater
   base07: "#7287fd" # lavender

--- a/base16/catppuccin-macchiato.yaml
+++ b/base16/catppuccin-macchiato.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#24273a" # base
-  base01: "#1e2030" # mantle
-  base02: "#363a4f" # surface0
-  base03: "#494d64" # surface1
-  base04: "#5b6078" # surface2
+  base01: "#363a4f" # surface0
+  base02: "#494d64" # surface1
+  base03: "#6e738d" # overlay0
+  base04: "#a5adcb" # subtext0
   base05: "#cad3f5" # text
   base06: "#f4dbd6" # rosewater
   base07: "#b7bdf8" # lavender

--- a/base16/catppuccin-mocha.yaml
+++ b/base16/catppuccin-mocha.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#1e1e2e" # base
-  base01: "#181825" # mantle
-  base02: "#313244" # surface0
-  base03: "#45475a" # surface1
-  base04: "#585b70" # surface2
+  base01: "#313244" # surface0
+  base02: "#45475a" # surface1
+  base03: "#6c7086" # overlay0
+  base04: "#a6adc8" # subtext0
   base05: "#cdd6f4" # text
   base06: "#f5e0dc" # rosewater
   base07: "#b4befe" # lavender

--- a/base24/catppuccin-frappe.yaml
+++ b/base24/catppuccin-frappe.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#303446" # base
-  base01: "#292c3c" # mantle
-  base02: "#414559" # surface0
-  base03: "#51576d" # surface1
-  base04: "#626880" # surface2
+  base01: "#414559" # surface0
+  base02: "#51576d" # surface1
+  base03: "#737994" # overlay0
+  base04: "#a5adce" # subtext0
   base05: "#c6d0f5" # text
   base06: "#f2d5cf" # rosewater
   base07: "#babbf1" # lavender

--- a/base24/catppuccin-latte.yaml
+++ b/base24/catppuccin-latte.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "light"
 palette:
   base00: "#eff1f5" # base
-  base01: "#e6e9ef" # mantle
-  base02: "#ccd0da" # surface0
-  base03: "#bcc0cc" # surface1
-  base04: "#acb0be" # surface2
+  base01: "#ccd0da" # surface0
+  base02: "#bcc0cc" # surface1
+  base03: "#9ca0b0" # overlay0
+  base04: "#6c6f85" # subtext0
   base05: "#4c4f69" # text
   base06: "#dc8a78" # rosewater
   base07: "#7287fd" # lavender

--- a/base24/catppuccin-macchiato.yaml
+++ b/base24/catppuccin-macchiato.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#24273a" # base
-  base01: "#1e2030" # mantle
-  base02: "#363a4f" # surface0
-  base03: "#494d64" # surface1
-  base04: "#5b6078" # surface2
+  base01: "#363a4f" # surface0
+  base02: "#494d64" # surface1
+  base03: "#6e738d" # overlay0
+  base04: "#a5adcb" # subtext0
   base05: "#cad3f5" # text
   base06: "#f4dbd6" # rosewater
   base07: "#b7bdf8" # lavender

--- a/base24/catppuccin-mocha.yaml
+++ b/base24/catppuccin-mocha.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#1e1e2e" # base
-  base01: "#181825" # mantle
-  base02: "#313244" # surface0
-  base03: "#45475a" # surface1
-  base04: "#585b70" # surface2
+  base01: "#313244" # surface0
+  base02: "#45475a" # surface1
+  base03: "#6c7086" # overlay0
+  base04: "#a6adc8" # subtext0
   base05: "#cdd6f4" # text
   base06: "#f5e0dc" # rosewater
   base07: "#b4befe" # lavender


### PR DESCRIPTION
I played around with the colors and found a perfect mapping that honors the base16/24 spec. I themed my nvim with the colors and hl group `Comment` (for base03), `Visual`  (for base02) and the statusline (for base01 and base04) looks beautiful. 

All colors are according to the [catppuccin spec](https://catppuccin.com/palette/).

Closes https://github.com/tinted-theming/schemes/issues/87 
Closes https://github.com/tinted-theming/tinted-nvim/issues/30

## Frappe:
<img width="298" height="109" alt="image" src="https://github.com/user-attachments/assets/703bd599-5618-4aec-85aa-e9d77034ad93" />

## Macchiato
<img width="303" height="113" alt="image" src="https://github.com/user-attachments/assets/1b65d80e-d72b-433c-b8eb-e45713b7a89c" />

## Mocha:
<img width="312" height="111" alt="image" src="https://github.com/user-attachments/assets/c032b07f-c9b1-483f-a862-82bbcd346109" />

## Latte
<img width="308" height="109" alt="image" src="https://github.com/user-attachments/assets/0033e822-d1a6-4ac8-950b-6850aa303573" />
