### PR TITLE
Revert "fix: Update catppuccin colors acording to the spec (#92)"

### DIFF
--- a/base16/catppuccin-frappe.yaml
+++ b/base16/catppuccin-frappe.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#303446" # base
-  base01: "#414559" # surface0
-  base02: "#51576d" # surface1
-  base03: "#737994" # overlay0
-  base04: "#a5adce" # subtext0
+  base01: "#292c3c" # mantle
+  base02: "#414559" # surface0
+  base03: "#51576d" # surface1
+  base04: "#626880" # surface2
   base05: "#c6d0f5" # text
   base06: "#f2d5cf" # rosewater
   base07: "#babbf1" # lavender

--- a/base16/catppuccin-latte.yaml
+++ b/base16/catppuccin-latte.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "light"
 palette:
   base00: "#eff1f5" # base
-  base01: "#ccd0da" # surface0
-  base02: "#bcc0cc" # surface1
-  base03: "#9ca0b0" # overlay0
-  base04: "#6c6f85" # subtext0
+  base01: "#e6e9ef" # mantle
+  base02: "#ccd0da" # surface0
+  base03: "#bcc0cc" # surface1
+  base04: "#acb0be" # surface2
   base05: "#4c4f69" # text
   base06: "#dc8a78" # rosewater
   base07: "#7287fd" # lavender

--- a/base16/catppuccin-macchiato.yaml
+++ b/base16/catppuccin-macchiato.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#24273a" # base
-  base01: "#363a4f" # surface0
-  base02: "#494d64" # surface1
-  base03: "#6e738d" # overlay0
-  base04: "#a5adcb" # subtext0
+  base01: "#1e2030" # mantle
+  base02: "#363a4f" # surface0
+  base03: "#494d64" # surface1
+  base04: "#5b6078" # surface2
   base05: "#cad3f5" # text
   base06: "#f4dbd6" # rosewater
   base07: "#b7bdf8" # lavender

--- a/base16/catppuccin-mocha.yaml
+++ b/base16/catppuccin-mocha.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#1e1e2e" # base
-  base01: "#313244" # surface0
-  base02: "#45475a" # surface1
-  base03: "#6c7086" # overlay0
-  base04: "#a6adc8" # subtext0
+  base01: "#181825" # mantle
+  base02: "#313244" # surface0
+  base03: "#45475a" # surface1
+  base04: "#585b70" # surface2
   base05: "#cdd6f4" # text
   base06: "#f5e0dc" # rosewater
   base07: "#b4befe" # lavender

--- a/base24/catppuccin-frappe.yaml
+++ b/base24/catppuccin-frappe.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#303446" # base
-  base01: "#414559" # surface0
-  base02: "#51576d" # surface1
-  base03: "#737994" # overlay0
-  base04: "#a5adce" # subtext0
+  base01: "#292c3c" # mantle
+  base02: "#414559" # surface0
+  base03: "#51576d" # surface1
+  base04: "#626880" # surface2
   base05: "#c6d0f5" # text
   base06: "#f2d5cf" # rosewater
   base07: "#babbf1" # lavender

--- a/base24/catppuccin-latte.yaml
+++ b/base24/catppuccin-latte.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "light"
 palette:
   base00: "#eff1f5" # base
-  base01: "#ccd0da" # surface0
-  base02: "#bcc0cc" # surface1
-  base03: "#9ca0b0" # overlay0
-  base04: "#6c6f85" # subtext0
+  base01: "#e6e9ef" # mantle
+  base02: "#ccd0da" # surface0
+  base03: "#bcc0cc" # surface1
+  base04: "#acb0be" # surface2
   base05: "#4c4f69" # text
   base06: "#dc8a78" # rosewater
   base07: "#7287fd" # lavender

--- a/base24/catppuccin-macchiato.yaml
+++ b/base24/catppuccin-macchiato.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#24273a" # base
-  base01: "#363a4f" # surface0
-  base02: "#494d64" # surface1
-  base03: "#6e738d" # overlay0
-  base04: "#a5adcb" # subtext0
+  base01: "#1e2030" # mantle
+  base02: "#363a4f" # surface0
+  base03: "#494d64" # surface1
+  base04: "#5b6078" # surface2
   base05: "#cad3f5" # text
   base06: "#f4dbd6" # rosewater
   base07: "#b7bdf8" # lavender

--- a/base24/catppuccin-mocha.yaml
+++ b/base24/catppuccin-mocha.yaml
@@ -4,10 +4,10 @@ author: "https://github.com/catppuccin/catppuccin"
 variant: "dark"
 palette:
   base00: "#1e1e2e" # base
-  base01: "#313244" # surface0
-  base02: "#45475a" # surface1
-  base03: "#6c7086" # overlay0
-  base04: "#a6adc8" # subtext0
+  base01: "#181825" # mantle
+  base02: "#313244" # surface0
+  base03: "#45475a" # surface1
+  base04: "#585b70" # surface2
   base05: "#cdd6f4" # text
   base06: "#f5e0dc" # rosewater
   base07: "#b4befe" # lavender


### PR DESCRIPTION
This reverts commit 0c25cbcb7bc5e656577f60adf25be5011feabbe5 due to discussion that's continued in the PR after merge: https://github.com/tinted-theming/schemes/pull/92. We will discuss in tinted-theming/home to decide how we should handle the styleguide suggestions in schemes.