### PR TITLE
tinted8: Fix "accent" variable to match latest tinted8 spec

### DIFF
--- a/tinted8/nord.yaml
+++ b/tinted8/nord.yaml
@@ -47,4 +47,4 @@ ui:
   gutter:
     foreground: "#434c5e"
   status.info: "#ebcb8b"
-  accent: "#88c0d0"
+  accent.normal: "#88c0d0"


### PR DESCRIPTION
- styling spec 0.2.0-beta6