### PR TITLE
Add Neovim Default Themes

### DIFF
--- a/base16/neovim-dark.yaml
+++ b/base16/neovim-dark.yaml
@@ -1,0 +1,21 @@
+system: "base16"
+name: "Neovim Dark"
+author: "https://github.com/neovim/neovim/blob/master/src/nvim/highlight_group.c"
+variant: "dark"
+palette:
+  base00: "#14161b" # NvimDarkGrey2    — Normal bg
+  base01: "#07080d" # NvimDarkGrey1    — Float bg (NormalFloat/Pmenu)
+  base02: "#4f5258" # NvimDarkGrey4    — Visual / StatusLine bg
+  base03: "#9b9ea4" # NvimLightGrey4   — Comment
+  base04: "#c4c6cd" # NvimLightGrey3   — dark foreground (ramp)
+  base05: "#e0e2ea" # NvimLightGrey2   — Normal fg
+  base06: "#eef1f8" # NvimLightGrey1   — light foreground
+  base07: "#eef1f8" # NvimLightGrey1   — lightest (no grey above LightGrey1)
+  base08: "#ffc0b9" # NvimLightRed     — red     (DiagnosticError/Removed)
+  base09: "#ffa500" # Orange           — orange  (no Nvim* orange exists)
+  base0A: "#fce094" # NvimLightYellow  — yellow  (DiagnosticWarn)
+  base0B: "#b3f6c0" # NvimLightGreen   — green   (DiagnosticOk/Added/String)
+  base0C: "#8cf8f7" # NvimLightCyan    — cyan    (DiagnosticInfo/Special/Directory)
+  base0D: "#a6dbff" # NvimLightBlue    — blue    (DiagnosticHint/Identifier)
+  base0E: "#ffcaff" # NvimLightMagenta — magenta (unused by default highlights)
+  base0F: "#cd853f" # Peru             — brown   (no Nvim* brown exists)

--- a/base16/neovim-light.yaml
+++ b/base16/neovim-light.yaml
@@ -1,0 +1,21 @@
+system: "base16"
+name: "Neovim Light"
+author: "https://github.com/neovim/neovim/blob/master/src/nvim/highlight_group.c"
+variant: "light"
+palette:
+  base00: "#e0e2ea" # NvimLightGrey2   — Normal bg
+  base01: "#eef1f8" # NvimLightGrey1   — Float bg (NormalFloat/Pmenu)
+  base02: "#9b9ea4" # NvimLightGrey4   — Visual / StatusLine bg
+  base03: "#4f5258" # NvimDarkGrey4    — Comment
+  base04: "#2c2e33" # NvimDarkGrey3    — dark foreground (ramp)
+  base05: "#14161b" # NvimDarkGrey2    — Normal fg
+  base06: "#07080d" # NvimDarkGrey1    — dark foreground
+  base07: "#07080d" # NvimDarkGrey1    — darkest (no grey below DarkGrey1)
+  base08: "#590008" # NvimDarkRed      — red     (DiagnosticError/Removed)
+  base09: "#8b4513" # SaddleBrown      — orange  (no Nvim* orange exists)
+  base0A: "#6b5300" # NvimDarkYellow   — yellow  (DiagnosticWarn)
+  base0B: "#005523" # NvimDarkGreen    — green   (DiagnosticOk/Added/String)
+  base0C: "#007373" # NvimDarkCyan     — cyan    (DiagnosticInfo/Special/Directory)
+  base0D: "#004c73" # NvimDarkBlue     — blue    (DiagnosticHint/Identifier)
+  base0E: "#470045" # NvimDarkMagenta  — magenta (unused by default highlights)
+  base0F: "#a52a2a" # Brown            — brown   (no Nvim* brown exists)


### PR DESCRIPTION
I quite like the default neovim theme and want to extend it to other tools. These schemes were designed with colors extracted from inside Neovim and in accordance with `:h dev-theme`

```lua
local t={}
for n,v in pairs(vim.api.nvim_get_color_map()) do 
	t[n]=("#%06x"):format(v) 
end 
vim.print(t)
```

Stumbled across tinted-schemes just a few days ago and this is a fantastic theming system!