### PR TITLE
fix(base24): correct variant and base07 data in FredHappyface schemes

### DIFF
--- a/base24/3024-day.yaml
+++ b/base24/3024-day.yaml
@@ -10,7 +10,7 @@ palette:
   base04: "#807d7b"
   base05: "#928f8e"
   base06: "#a5a2a2"
-  base07: "#f7f7f7"
+  base07: "#090300"
   base08: "#db2d20"
   base09: "#fded02"
   base0A: "#807d7c"

--- a/base24/blue-berry-pie.yaml
+++ b/base24/blue-berry-pie.yaml
@@ -10,7 +10,7 @@ palette:
   base04: "#877e86"
   base05: "#bbb2ad"
   base06: "#f0e7d5"
-  base07: "#0a6b7e"
+  base07: "#f0e7d5"
   base08: "#99236d"
   base09: "#e9b8a7"
   base0A: "#38163d"

--- a/base24/builtin-light.yaml
+++ b/base24/builtin-light.yaml
@@ -10,7 +10,7 @@ palette:
   base04: "#888888"
   base05: "#a1a1a1"
   base06: "#bbbbbb"
-  base07: "#ffffff"
+  base07: "#000000"
   base08: "#bb0000"
   base09: "#bbbb00"
   base0A: "#5555ff"

--- a/base24/builtin-solarized-light.yaml
+++ b/base24/builtin-solarized-light.yaml
@@ -10,7 +10,7 @@ palette:
   base04: "#778985"
   base05: "#b2b8ad"
   base06: "#eee8d5"
-  base07: "#fdf6e3"
+  base07: "#002b36"
   base08: "#dc322f"
   base09: "#b58900"
   base0A: "#839496"

--- a/base24/elementary.yaml
+++ b/base24/elementary.yaml
@@ -10,7 +10,7 @@ palette:
   base04: "#9c9c9c"
   base05: "#c5c5c5"
   base06: "#eeeeee"
-  base07: "#8c00eb"
+  base07: "#eeeeee"
   base08: "#d61b15"
   base09: "#fdb40b"
   base0A: "#0855fe"

--- a/base24/front-end-delight.yaml
+++ b/base24/front-end-delight.yaml
@@ -10,7 +10,7 @@ palette:
   base04: "#85ac8c"
   base05: "#98ac9c"
   base06: "#acacac"
-  base07: "#8b735a"
+  base07: "#acacac"
   base08: "#f8501a"
   base09: "#f9761d"
   base0A: "#3393c9"

--- a/base24/one-half-light.yaml
+++ b/base24/one-half-light.yaml
@@ -1,7 +1,7 @@
 system: "base24"
 name: "One Half Light"
 author: "FredHappyface (https://github.com/fredHappyface)"
-variant: "light"
+variant: "dark"
 palette:
   base00: "#2A2B32"
   base01: "#373942"

--- a/base24/pencil-light.yaml
+++ b/base24/pencil-light.yaml
@@ -10,7 +10,7 @@ palette:
   base04: "#8d8d8d"
   base05: "#b3b3b3"
   base06: "#d9d9d9"
-  base07: "#f1f1f1"
+  base07: "#212121"
   base08: "#c30771"
   base09: "#a89c14"
   base0A: "#20bbfc"

--- a/base24/warm-neon.yaml
+++ b/base24/warm-neon.yaml
@@ -1,7 +1,7 @@
 system: "base24"
 name: "Warm Neon"
 author: "FredHappyface (https://github.com/fredHappyface)"
-variant: "light"
+variant: "dark"
 palette:
   base00: "#3f3f3f"
   base01: "#000000"


### PR DESCRIPTION
Fixes three classes of data errors in FredHappyface's base24 conversions.

## 1. `variant` marked `light` but scheme is actually dark (2 files)
`one-half-light.yaml`, `warm-neon.yaml` declare `variant: "light"` while their
`base00` is a dark color (`#2A2B32` / `#3f3f3f`) and `base05` is lighter —
the standard dark-mode shape. Consumers relying on `variant` for theme
detection (light/dark toggle, contrast logic) get it backwards.
→ Set `variant: "dark"`.

## 2. Light-theme `base07` copied from `base00` (4 files)
`3024-day`, `builtin-light`, `builtin-solarized-light`, `pencil-light` set
`base07` to the same value as `base00` (the background). Per the base16
spec, in light variants `base07` is the darkest foreground. This makes the
"white" ANSI slot and the light-variant surface equal to the background —
unreadable text on UI surfaces.
→ `3024-day: #090300`, `builtin-light: #000000`,
`builtin-solarized-light: #002b36` (matches the base16 definition),
`pencil-light: #212121`.

## 3. Dark-theme `base07` filled with accent/deep colors (3 files)
`blue-berry-pie` (`#0a6b7e`), `elementary` (`#8c00eb`), `front-end-delight`
(`#8b735a`) put an accent or brown color in the `base07` slot, which should
be the lightest neutral. The "white" ANSI key and lightest-foreground
consumers render wrong.
→ Set to the scheme's `base06` (lightest neutral): `#f0e7d5`, `#eeeeee`,
`#acacac`.

All 9 files are in `base24/`. No base16 files are affected.